### PR TITLE
feat(devcontainer): add Ollama model persistence configuration (#6)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,15 @@
       ]
     }
   },
-  "postCreateCommand": "mkdir -p ~/.claude"
+
+  // ============================================================
+  // Ollama Configuration (Default: ON)
+  // To disable: Comment out or remove the containerEnv and
+  // ollama-related postCreateCommand sections below
+  // ============================================================
+  "containerEnv": {
+    "OLLAMA_MODELS": "/workspaces/${localWorkspaceFolderBasename}/data/shared/ollama_models"
+  },
+
+  "postCreateCommand": "mkdir -p ~/.claude && mkdir -p /workspaces/${localWorkspaceFolderBasename}/data/shared/ollama_models"
 }

--- a/README-ja.md
+++ b/README-ja.md
@@ -168,6 +168,16 @@ claude
 - 追加パッケージのインストール
 - VS Code拡張機能の追加
 
+### Ollamaモデルの永続化
+
+デフォルトでOllamaモデルの永続化は**有効**です。モデルは `data/shared/ollama_models/` に保存され、コンテナ再ビルド後も保持されます。
+
+**Ollama永続化を無効にする場合:**
+
+`.devcontainer/devcontainer.json` を編集し、以下を削除またはコメントアウトしてください:
+1. `containerEnv` セクション（`OLLAMA_MODELS`）
+2. `postCreateCommand` 内の `ollama_models` 部分
+
 ## ライセンス
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -172,6 +172,16 @@ Edit `.devcontainer/` to customize:
 - Additional packages
 - VS Code extensions
 
+### Ollama Model Persistence
+
+By default, Ollama model persistence is **enabled**. Models are stored in `data/shared/ollama_models/` and persist across container rebuilds.
+
+**To disable Ollama persistence:**
+
+Edit `.devcontainer/devcontainer.json` and remove or comment out:
+1. The `containerEnv` section with `OLLAMA_MODELS`
+2. The `ollama_models` part in `postCreateCommand`
+
 ---
 
 ## License


### PR DESCRIPTION
Closes #6

## 変更概要

devcontainer環境でOllamaモデルを永続化する設定を追加。コンテナ再ビルド後もモデルファイルが保持されるようになります。

### 主な変更点
- `containerEnv`に`OLLAMA_MODELS`環境変数を追加
- `postCreateCommand`でモデルディレクトリを自動作成
- README（EN/JA）にドキュメント追加

### 設計
- **デフォルト ON**: Ollama設定は有効な状態で提供
- **オプションとして無効化可能**: コメントアウトで切り替え
- モデルは `data/shared/ollama_models/` に保存（`.gitignore`対象）

## 品質チェック
- ✅ コードレビュー実施済み
- ✅ Issue要件を満たしていることを確認
- ✅ ドキュメント追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)