### PR TITLE
fix(devcontainer): add fixed hostname to prevent auth re-confirmation (#8)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
     "--gpus=all",
     "--shm-size=64gb",
     "--ulimit", "memlock=-1",
-    "--ulimit", "stack=67108864"
+    "--ulimit", "stack=67108864",
+    "--hostname", "devcontainer"
   ],
   "mounts": [
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",


### PR DESCRIPTION
Refs #8

## 変更概要

Docker rebuild時にClaude Code認証が毎回要求される問題への対策。

### 原因
コンテナ再ビルド時にホスト名が変わり、Claude Codeが「新しい環境」として認識

### 対策
`--hostname devcontainer` を追加してホスト名を固定化

## テスト計画
1. 再ビルド → 認証
2. 再度再ビルド → 認証確認が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)