### PR TITLE
docs: clarify GitHub repo creation for org accounts

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -44,8 +44,12 @@ chmod +x setup.sh
 ### 2. GitHubリポジトリを作成
 
 ```bash
+# 個人アカウントの場合
 gh repo create my-project --public
-git remote add origin https://github.com/YOUR_USERNAME/my-project.git
+
+# Organizationの場合
+gh repo create YOUR_ORG/my-project --public
+
 git push -u origin main
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,12 @@ chmod +x setup.sh
 ### 2. Create GitHub Repository
 
 ```bash
+# Personal account
 gh repo create my-project --public
-git remote add origin https://github.com/YOUR_USERNAME/my-project.git
+
+# Organization account
+gh repo create YOUR_ORG/my-project --public
+
 git push -u origin main
 ```
 


### PR DESCRIPTION
## Summary

- READMEの「Create GitHub Repository」セクションにorganization配下でのリポジトリ作成例を追加
- `git remote add origin` の手動ステップを削除（`gh repo create` が自動設定するため）
- 英語版・日本語版の両方を修正

## 変更の意図

`gh repo create my-project` だけでは個人アカウントに作成され、org用のremote URLと不一致になる問題があった。org配下に作る場合の手順（`gh repo create YOUR_ORG/my-project`）を明記することで、初回セットアップ時の混乱を防ぐ。

## 影響範囲

READMEのドキュメント変更のみ。テンプレートの機能・スクリプトへの影響なし。

---
*This PR was created via `/template/contribute` command.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)