### PR TITLE
docs: add model download storage rules to prevent /tmp usage

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -228,8 +228,9 @@ mv large_dataset.json data/shared/datasets/
 # 実験結果
 mv experiment_results.csv data/shared/results/
 
-# 学習済みモデル
+# 学習済みモデル・ダウンロードモデル
 mv best_model.pt data/shared/models/
+mv pretrained_weights.pth data/shared/models/
 ```
 
 **一時データ（削除OK）:**
@@ -239,6 +240,22 @@ mv preprocessed_batch.pkl data/local/cache/
 
 # デバッグ出力
 mv debug_images/ data/local/debug/
+```
+
+### モデル保存の注意事項
+
+**重要**: ダウンロードしたモデル（事前学習モデル、ベースラインモデルなど）は**絶対に `/tmp` に保存しない**。
+
+- ❌ `/tmp/models/` — devcontainer rebuild で消える
+- ❌ `~/.cache/` — devcontainer rebuild で消える
+- ✅ `data/shared/models/` — 永続化される
+
+```bash
+# 正しい例
+wget -O data/shared/models/resnet50.pth https://example.com/resnet50.pth
+
+# Pythonでダウンロードする場合も保存先を指定
+torch.hub.set_dir("data/shared/models")
 ```
 
 ---


### PR DESCRIPTION
## Summary

ダウンロードしたモデルの保存先ルールをCLAUDE.mdに明記。

## 背景

- Claudeがモデルをダウンロードする際、`/tmp` に保存する傾向がある
- devcontainerではrebuildの度に `/tmp` や `~/.cache/` の内容が消える
- `data/shared/models/` に保存すれば永続化される

## 変更内容

「Worktree データ保護」セクションに以下を追加：

- ❌ `/tmp/models/` — devcontainer rebuild で消える
- ❌ `~/.cache/` — devcontainer rebuild で消える
- ✅ `data/shared/models/` — 永続化される

```bash
# 正しい例
wget -O data/shared/models/resnet50.pth https://example.com/resnet50.pth

# Pythonでダウンロードする場合も保存先を指定
torch.hub.set_dir("data/shared/models")
```

## Test plan

- [ ] CLAUDE.mdを読んだClaude Codeがモデルを正しい場所に保存するか確認

---
*This PR was created via `/template/contribute` command.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)