### PR TITLE
feat(devcontainer): GPU アクセス喪失の事前チェックと警告

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,5 +43,9 @@
     "OLLAMA_MODELS": "/workspaces/${localWorkspaceFolderBasename}/data/shared/ollama_models"
   },
 
-  "postCreateCommand": "sudo chown -R $(id -u):$(id -g) /home/vscode/.claude && ln -sf /home/vscode/.claude/.claude.json /home/vscode/.claude.json && echo -n 'devcontainer-${localWorkspaceFolderBasename}' | md5sum | cut -c1-32 | sudo tee /etc/machine-id > /dev/null && mkdir -p \"/workspaces/${localWorkspaceFolderBasename}/data/shared/ollama_models\""
+  "initializeCommand": "bash .devcontainer/../scripts/check-nvidia-symlinks.sh 2>/dev/null || true",
+
+  "postCreateCommand": "sudo chown -R $(id -u):$(id -g) /home/vscode/.claude && ln -sf /home/vscode/.claude/.claude.json /home/vscode/.claude.json && echo -n 'devcontainer-${localWorkspaceFolderBasename}' | md5sum | cut -c1-32 | sudo tee /etc/machine-id > /dev/null && mkdir -p \"/workspaces/${localWorkspaceFolderBasename}/data/shared/ollama_models\"",
+
+  "postStartCommand": "nvidia-smi > /dev/null 2>&1 && echo '[GPU] Access OK' || echo '[GPU] WARNING: GPU access lost. Container restart required.' >&2"
 }

--- a/scripts/check-nvidia-symlinks.sh
+++ b/scripts/check-nvidia-symlinks.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ============================================================================
+# NVIDIA /dev/char/ Symlink Check
+#
+# Checks if /dev/char/ symlinks exist for NVIDIA devices. Without these,
+# long-running containers lose GPU access when the host runs
+# "systemctl daemon-reload" (triggered by automatic package updates, etc.).
+#
+# This is NVIDIA's official workaround using nvidia-ctk.
+# See: https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
+#
+# Usage:
+#   bash scripts/check-nvidia-symlinks.sh          # Check only
+#   sudo bash scripts/check-nvidia-symlinks.sh --fix  # Check and fix
+# ============================================================================
+
+set -euo pipefail
+
+FIX_MODE=false
+if [[ "${1:-}" == "--fix" ]]; then
+    FIX_MODE=true
+fi
+
+# Skip silently if no NVIDIA GPU
+if ! command -v nvidia-smi &> /dev/null; then
+    exit 0
+fi
+
+# Check if symlinks exist
+if ls /dev/char/195:* &> /dev/null 2>&1; then
+    echo "[GPU] /dev/char/ symlinks: OK"
+    exit 0
+fi
+
+# --- Symlinks missing ---
+
+if $FIX_MODE; then
+    if [[ $EUID -ne 0 ]]; then
+        echo "ERROR: --fix requires root. Run: sudo bash $0 --fix"
+        exit 1
+    fi
+    if ! command -v nvidia-ctk &> /dev/null; then
+        echo "ERROR: nvidia-ctk not found. Install NVIDIA Container Toolkit first."
+        exit 1
+    fi
+
+    echo "[GPU] Creating /dev/char/ symlinks..."
+    nvidia-ctk system create-dev-char-symlinks --create-all
+
+    echo "[GPU] Creating udev rule for persistence..."
+    echo 'ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all"' \
+        > /lib/udev/rules.d/71-nvidia-dev-char.rules
+    udevadm control --reload-rules
+
+    echo "[GPU] Done. Verify: ls /dev/char/195:*"
+    exit 0
+fi
+
+# --- Warning mode ---
+
+cat <<'MESSAGE'
+
+================================================================
+  WARNING: NVIDIA /dev/char/ symlinks not found
+================================================================
+
+  Long-running GPU containers will lose GPU access when the host
+  runs "systemctl daemon-reload" (triggered automatically by
+  package updates, logrotate, etc.).
+
+  This is a known Docker + systemd cgroup v2 issue.
+  NVIDIA provides an official fix via nvidia-ctk.
+
+  Run this command on the HOST (not inside the container):
+
+    sudo nvidia-ctk system create-dev-char-symlinks --create-all
+
+  To persist across host reboots, also run:
+
+    echo 'ACTION=="add", DEVPATH=="/bus/pci/drivers/nvidia", RUN+="/usr/bin/nvidia-ctk system create-dev-char-symlinks --create-all"' \
+      | sudo tee /lib/udev/rules.d/71-nvidia-dev-char.rules
+    sudo udevadm control --reload-rules
+
+  Or use the shortcut:
+
+    sudo bash scripts/check-nvidia-symlinks.sh --fix
+
+  Details: https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
+
+================================================================
+
+MESSAGE


### PR DESCRIPTION
## Summary

長時間稼働のGPUコンテナで `nvidia-smi` が `Failed to initialize NVML: Unknown Error` で死ぬ問題への対策。

### 根本原因
Docker cgroup v2 + systemd の既知バグ ([nvidia-container-toolkit#48](https://github.com/NVIDIA/nvidia-container-toolkit/issues/48))。ホスト側で `systemctl daemon-reload` が自動実行されると（パッケージ更新等）、`/dev/char/` シンボリックリンク未作成のNVIDIAデバイスのcgroupアクセスが剥がされる。`shutdownAction: "none"` で長期間稼働するdevcontainerで特に発生しやすい。

### 変更内容

| ファイル | 内容 |
|---------|------|
| `scripts/check-nvidia-symlinks.sh` | `/dev/char/` シンボリックリンクの存在チェック。未設定時にNVIDIA公式ワークアラウンド (`nvidia-ctk`) のコピペ可能なコマンドを警告表示。`--fix` オプションで自動修正も可能 |
| `.devcontainer/devcontainer.json` | `initializeCommand` でホスト側チェック実行、`postStartCommand` でコンテナ内GPUアクセス確認 |

### 動作例（symlink未設定時）

```
================================================================
  WARNING: NVIDIA /dev/char/ symlinks not found
================================================================

  Run this command on the HOST (not inside the container):

    sudo nvidia-ctk system create-dev-char-symlinks --create-all

  Details: https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
================================================================
```

## Test plan
- [x] symlink未設定環境で警告メッセージが正しく表示されることを確認
- [x] `--fix` モードでsudo権限チェックが機能することを確認
- [x] nvidia-smi未インストール環境でスクリプトがサイレントに終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)