### PR TITLE
fix(claude-san): always create new tmux session

### DIFF
--- a/claude-san
+++ b/claude-san
@@ -2,36 +2,30 @@
 # Claude Code + autoclaude セットアップスクリプト
 # rate limit 後に自動再開するための環境を起動
 
-# セッション名を生成（引数のハッシュまたはデフォルト）
-if [ $# -eq 0 ]; then
-    SESSION_NAME="claude-work"
-else
-    SESSION_NAME="claude-$(echo "$*" | md5sum | cut -c1-8)"
-fi
+# セッション名を生成（タイムスタンプで一意に）
+SESSION_NAME="claude-$(date +%H%M%S)"
 
 # 引数をそのままclaudeに渡す
 CLAUDE_ARGS="$*"
 CLAUDE_CMD="claude --dangerously-skip-permissions $CLAUDE_ARGS"
 
-# 既存セッションがあれば接続、なければ新規作成
-if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-    echo "既存セッションに接続: $SESSION_NAME"
-    tmux attach -t "$SESSION_NAME"
-else
-    echo "新規セッション作成: $SESSION_NAME"
-    echo "Claude args: $CLAUDE_ARGS"
-    tmux new-session -d -s "$SESSION_NAME"
-    tmux send-keys -t "$SESSION_NAME" "$CLAUDE_CMD" Enter
-    tmux split-window -h -l 50% -t "$SESSION_NAME"
-    tmux send-keys -t "$SESSION_NAME" 'autoclaude' Enter
-    tmux select-pane -t "$SESSION_NAME":0.0
-    tmux resize-pane -Z  # Claudeペインを最大化
-    tmux attach -t "$SESSION_NAME"
-fi
+echo "新規セッション作成: $SESSION_NAME"
+[ -n "$CLAUDE_ARGS" ] && echo "Claude args: $CLAUDE_ARGS"
+
+tmux new-session -d -s "$SESSION_NAME"
+tmux send-keys -t "$SESSION_NAME" "$CLAUDE_CMD" Enter
+tmux split-window -h -l 50% -t "$SESSION_NAME"
+tmux send-keys -t "$SESSION_NAME" 'autoclaude' Enter
+tmux select-pane -t "$SESSION_NAME":0.0
+tmux resize-pane -Z  # Claudeペインを最大化
+tmux attach -t "$SESSION_NAME"
 
 # 使い方:
-#   claude-san                    # 対話モード
-#   claude-san -c                 # 前回の会話を継続
+#   claude-san                    # 新規セッションで対話モード
+#   claude-san -c                 # 新規セッションで前回の会話を継続
 #   claude-san --continue         # 同上
-#   claude-san -r <session-id>    # 特定セッション再開
-#   claude-san -p "prompt"        # 非対話モード
+#   claude-san -r <session-id>    # 新規セッションで特定セッション再開
+#
+# 既存tmuxセッションに接続:
+#   tmux attach -t <session-name>
+#   tmux ls  # セッション一覧


### PR DESCRIPTION
## Summary

- Use timestamp for unique session names (always new session)
- Remove existing session reconnection logic
- Simpler and more predictable behavior

## Usage

```bash
claude-san                    # 新規セッション
claude-san -c                 # 新規セッションで前回会話継続
tmux ls                       # セッション一覧
tmux attach -t claude-xxx     # 既存に接続
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)