### PR TITLE
docs: Update README/README-ja with missing features (#34)

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -1,13 +1,17 @@
 # Research Project Template
 
-Claude Code を活用した研究プロジェクト用テンプレートです。
+Claude Code を活用した研究プロジェクト用テンプレートです。**VS Code DevContainer** でGPU対応の開発環境が一発で起動します。
+
+[English](README.md) | [中文](README-zh.md)
 
 ## 特徴
 
-- **Issue駆動開発**: GitHub Issueを中心としたワークフロー
+- **VS Code DevContainer**: GPU対応、Claude Code・GitHub CLI・autoclaude等がプリインストール済み
+- **Issue駆動開発**: GitHub Issueを中心としたワークフロー、`/issue/auto` による一括処理対応
 - **Git Worktree管理**: 並行タスクを独立したディレクトリで管理
 - **データ保護**: 重要データとWorktreeの分離
-- **Claude Code統合**: カスタムスキルによる自動化
+- **Claude Code統合**: カスタムスキルによる自動化、`claude-san` でrate limit時自動再開
+- **Human-in-the-Loop QA**: Slack/Discord経由でタスク実行中に人間へ質問
 
 ---
 
@@ -58,7 +62,9 @@ git push -u origin main
 VS Code で Dev Container を使用する場合:
 1. VS Code でプロジェクトを開く
 2. "Reopen in Container" を選択
-3. Claude Code を起動: `claude`
+3. Claude Code を起動: `claude-san`（rate limit時に自動再開、tmux + [autoclaude](https://github.com/henryaj/autoclaude)）
+
+> 詳細は [docs/claude-san.md](docs/claude-san.md) を参照。通常の `claude` コマンドも使用可能です。
 
 ---
 
@@ -105,10 +111,15 @@ my-project/
 | `/issue/branch [説明]` | 現在のWorktree内で子タスクを作成 |
 | `/issue/report` | 進捗をIssueに報告 |
 | `/issue/finish` | タスクを完了（レビュー + マージ + クリーンアップ） |
+| `/issue/auto [ids...]` | 複数Issueを自動処理（スナップショット付き） |
 | `/commit` | ローカルにコミット |
 | `/commit/push` | コミット＆プッシュ（途中保存） |
 | `/commit/merge` | コミット＆マージ（タスク完了） |
 | `/review` | 多角的コードレビュー |
+| `/review-spec` | 実装前の仕様レビュー・検証 |
+| `/qa/setup` | QAシステムのセットアップ（Slack/Discord） |
+| `/qa/ask` | 人間に質問を送信 |
+| `/qa/check` | 未回答の質問を確認 |
 | `/template/sync` | テンプレートの最新更新を取り込み |
 | `/template/contribute` | テンプレートへの改善PRを作成 |
 
@@ -123,6 +134,16 @@ my-project/
 - **`.devcontainer/devcontainer.json`**: VS Code拡張機能、環境変数
 
 詳細なカスタマイズ手順は `.claude/CLAUDE.md` を参照してください。
+
+---
+
+## ドキュメント
+
+| ドキュメント | 内容 |
+|-------------|------|
+| [docs/claude-san.md](docs/claude-san.md) | claude-san の使い方（tmux + autoclaude） |
+| [docs/devcontainer-internals.md](docs/devcontainer-internals.md) | DevContainer 自動化の仕組み |
+| [docs/security.md](docs/security.md) | 自動化機能のセキュリティ分析 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Research Project Template
 
-A project template for Claude Code integration with research workflows.
+A project template for Claude Code integration with research workflows. Runs as a **VS Code DevContainer** with GPU support, Claude Code, and all tools pre-installed.
 
-[日本語](README-ja.md)
+[日本語](README-ja.md) | [中文](README-zh.md)
 
 ## Features
 
-- **Issue-Driven Development**: GitHub Issue-centered workflow
+- **VS Code DevContainer**: One-click setup with GPU support, Claude Code, GitHub CLI, and autoclaude pre-installed
+- **Issue-Driven Development**: GitHub Issue-centered workflow with `/issue/auto` for batch processing
 - **Git Worktree Management**: Parallel tasks in isolated directories
 - **Data Protection**: Separation of important data and worktrees
-- **Claude Code Integration**: Custom skills for automation
+- **Claude Code Integration**: Custom skills for automation, rate-limit auto-resume via `claude-san`
+- **Human-in-the-Loop QA**: Ask questions to humans via Slack/Discord during task execution
 
 ---
 
@@ -62,7 +64,9 @@ gh repo create YOUR_ORG/my-project --source=. --push --private
 With VS Code Dev Container:
 1. Open project in VS Code
 2. Select "Reopen in Container"
-3. Start Claude Code: `claude`
+3. Start Claude Code: `claude-san` (auto-resumes on rate limit via tmux + [autoclaude](https://github.com/henryaj/autoclaude))
+
+> See [docs/claude-san.md](docs/claude-san.md) for details. You can also use `claude` directly for a plain session.
 
 ---
 
@@ -109,10 +113,15 @@ my-project/
 | `/issue/branch [desc]` | Create child task in current worktree |
 | `/issue/report` | Report progress to Issue |
 | `/issue/finish` | Complete task (review + merge + cleanup) |
+| `/issue/auto [ids...]` | Auto-process multiple Issues in sequence (with snapshot) |
 | `/commit` | Local commit only |
 | `/commit/push` | Commit & push (save progress) |
 | `/commit/merge` | Commit & merge (complete task) |
 | `/review` | Multi-perspective code review |
+| `/review-spec` | Review and validate specification before implementation |
+| `/qa/setup` | Set up QA system (Slack/Discord) |
+| `/qa/ask` | Ask a question to humans |
+| `/qa/check` | Check for unanswered questions |
 | `/template/sync` | Sync updates from template |
 | `/template/contribute` | Contribute improvements to template |
 
@@ -127,6 +136,16 @@ You can customize the following:
 - **`.devcontainer/devcontainer.json`**: VS Code extensions, environment variables
 
 See `.claude/CLAUDE.md` for detailed customization instructions.
+
+---
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [docs/claude-san.md](docs/claude-san.md) | claude-san usage guide (tmux + autoclaude) |
+| [docs/devcontainer-internals.md](docs/devcontainer-internals.md) | DevContainer automation internals |
+| [docs/security.md](docs/security.md) | Security analysis of automation features |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add DevContainer, claude-san, /issue/auto, /qa/*, /review-spec to Features and Skills table
- Update Quick Start to recommend `claude-san` for rate-limit auto-resume
- Add Documentation section linking to detailed docs (claude-san, devcontainer-internals, security)
- Add Chinese language link

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)