### PR TITLE
fix(claude-san): Auto-enable autoclaude monitoring after startup

### DIFF
--- a/claude-san
+++ b/claude-san
@@ -16,6 +16,10 @@ tmux new-session -d -s "$SESSION_NAME"
 tmux send-keys -t "$SESSION_NAME" "$CLAUDE_CMD" Enter
 tmux split-window -h -l 50% -t "$SESSION_NAME"
 tmux send-keys -t "$SESSION_NAME" 'autoclaude' Enter
+
+# バックグラウンドで5秒後に'a'キーを送信（autoclaudeの起動を待つ）
+(sleep 5 && tmux send-keys -t "$SESSION_NAME":0.1 'a') &
+
 tmux select-pane -t "$SESSION_NAME":0.0
 tmux resize-pane -Z  # Claudeペインを最大化
 tmux attach -t "$SESSION_NAME"


### PR DESCRIPTION
## 変更概要

`claude-san`起動時に、autoclaude の自動継続機能を自動で有効化するように修正。

## 変更内容

- 起動5秒後にautoclaudeペインに`a`キーを送信
- これにより全Claude Codeペーンの自動継続が有効化される

## 変更の意図

従来、rate limit後の自動復帰にはユーザーがautoclaudeペインで手動で`a`キーを押す必要があった。これを忘れると、rate limit解除後も自動復帰せず、処理が止まったままになる問題があった。

## 影響範囲

- `claude-san`を使用する全ユーザーに恩恵
- 起動時に3秒程度のバックグラウンド処理が追加されるが、ユーザー体験に影響なし

---
*This PR was created via `/template/contribute` command.*