### PR TITLE
fix(devcontainer): Add uv package manager installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,6 +43,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get update && apt-get install -y gh && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# uv をインストール（高速Pythonパッケージマネージャー）
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
 # Node.js 20をインストール（Claude Code用）
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \


### PR DESCRIPTION
## 変更概要

Dockerfileに`uv`パッケージマネージャーのインストールを追加。

## 問題

`scripts/quality-check.sh`は`uv`コマンドを使用しているが、Dockerfileに`uv`のインストールがなかった。そのため、devcontainerで品質チェックを実行すると`uv: command not found`エラーが発生していた。

## 変更内容

```dockerfile
# uv をインストール（高速Pythonパッケージマネージャー）
RUN curl -LsSf https://astral.sh/uv/install.sh | sh
ENV PATH="/root/.local/bin:${PATH}"
```

## 影響範囲

- テンプレートを使用する全プロジェクトで品質チェックが正常に動作するようになる
- devcontainer再ビルドが必要

---
*This PR was created via `/template/contribute` command.*