### PR TITLE
feat(skills): Add /issue/backlog and /issue/unblock skills

### DIFF
--- a/.claude/commands/issue/backlog.md
+++ b/.claude/commands/issue/backlog.md
@@ -1,0 +1,236 @@
+---
+description: Process backlog - unblock then issue-ify ready items (バックログ処理)
+---
+
+# Issue Backlog
+
+バックログ (`docs/backlog.md`) を処理します:
+1. `/issue/unblock` でブロッカー解消Issueを作成
+2. ブロッカーがない項目をIssue化
+3. Issue化した項目を backlog.md から削除
+
+## Usage
+
+```
+/issue/backlog              # フル処理（unblock + Issue化 + 削除）
+/issue/backlog --dry-run    # 分析のみ、変更しない
+/issue/backlog --skip-unblock  # unblockをスキップ（Issue化のみ）
+```
+
+## Concept
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    /issue/backlog                           │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   Step 1: /issue/unblock 呼び出し                          │
+│   ┌─────────────────────────────────────────────────────┐  │
+│   │ ブロッカー分析 → 自動解消Issue作成                  │  │
+│   │ 例: Issue #70: test(retriever): Add real FAISS E2E │  │
+│   └─────────────────────────────────────────────────────┘  │
+│                              │                              │
+│                              ▼                              │
+│   Step 2: ブロッカーなし項目のIssue化                      │
+│   ┌─────────────────────────────────────────────────────┐  │
+│   │ BL-007: ROS2 Executor                               │  │
+│   │   ブロッカー: HTTPExecutor実装完了 ✅               │  │
+│   │   → Issue #71: feat(executor): Add ROS2 Executor   │  │
+│   └─────────────────────────────────────────────────────┘  │
+│                              │                              │
+│                              ▼                              │
+│   Step 3: backlog.md から削除                              │
+│   ┌─────────────────────────────────────────────────────┐  │
+│   │ docs/backlog.md:                                    │  │
+│   │ - BL-007 セクションを削除                           │  │
+│   │ - "Moved to Issue #71" コメントを残す（オプション） │  │
+│   └─────────────────────────────────────────────────────┘  │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Workflow
+
+### Phase 1: /issue/unblock 呼び出し
+
+```
+Skill(skill="issue/unblock")
+```
+
+これにより:
+- ブロッカーが分類される（🤖自動 / 👤ユーザー / ⏸️依存待ち）
+- 自動解消可能なブロッカーのIssueが作成される
+
+### Phase 2: ブロッカーなし項目の特定
+
+```
+Task(subagent_type="general-purpose", prompt="
+docs/backlog.md を分析し、ブロッカーがない（着手可能な）項目を特定してください。
+
+## 着手可能の条件
+
+1. 「後回しにした理由」が解消されている
+   - 前提条件となる実装が完了している
+   - 依存するBL項目がない、または依存BLが完了済み
+
+2. ユーザー確認が不要
+   - 実ハードウェア/サーバーでの確認が不要
+   - 実運用検証が不要
+
+## 確認方法
+
+各項目について:
+1. 「後回しにした理由」を確認
+2. その理由が解消されているかをコードベースで確認
+3. 依存BL項目があれば、その状態を確認
+
+## 出力形式
+
+### 着手可能な項目
+
+| BL ID | タイトル | 理由が解消された根拠 |
+|-------|---------|---------------------|
+| BL-007 | ROS2 Executor | HTTPExecutor実装完了 |
+
+### 着手不可の項目
+
+| BL ID | タイトル | 残ブロッカー |
+|-------|---------|-------------|
+| BL-001 | FeedbackMonitor | 実ハードウェア確認必要（👤） |
+")
+```
+
+### Phase 3: Issue作成
+
+着手可能な項目をIssue化:
+
+```bash
+for BL_ITEM in $READY_ITEMS; do
+  BL_ID=$(echo "$BL_ITEM" | jq -r '.id')
+  BL_TITLE=$(echo "$BL_ITEM" | jq -r '.title')
+  BL_DESCRIPTION=$(echo "$BL_ITEM" | jq -r '.description')
+  BL_CONSIDERATIONS=$(echo "$BL_ITEM" | jq -r '.considerations')
+
+  NEW_ISSUE=$(gh issue create \
+    --title "feat: ${BL_TITLE}" \
+    --body "## 概要
+
+${BL_DESCRIPTION}
+
+## 背景
+
+バックログ項目 ${BL_ID} より。
+ブロッカーが解消されたため、Issue化しました。
+
+## 実装時の考慮点
+
+${BL_CONSIDERATIONS}
+
+## 関係
+- From Backlog: ${BL_ID}
+
+---
+*このIssueは /issue/backlog により自動生成されました*" \
+    --label "feature")
+
+  echo "Created: $NEW_ISSUE for $BL_ID"
+  CREATED_ISSUES+=("$BL_ID:$NEW_ISSUE")
+done
+```
+
+### Phase 4: backlog.md から削除
+
+Issue化した項目を backlog.md から削除:
+
+```bash
+for ITEM in $CREATED_ISSUES; do
+  BL_ID=$(echo "$ITEM" | cut -d: -f1)
+  ISSUE_URL=$(echo "$ITEM" | cut -d: -f2)
+
+  # 該当セクションを削除（または移動コメントを残す）
+  # セクションの開始: ### BL-XXX:
+  # セクションの終了: 次の ### または ---
+
+  # オプション1: 完全削除
+  sed -i "/### ${BL_ID}:/,/^---$/d" docs/backlog.md
+
+  # オプション2: 移動コメントを残す（推奨）
+  # sed -i "s/### ${BL_ID}:.*/### ${BL_ID}: [Moved to ${ISSUE_URL}]/" docs/backlog.md
+done
+
+# 変更をコミット
+git add docs/backlog.md
+git commit -m "chore(backlog): Move ${BL_ID} to Issue
+
+Items moved to GitHub Issues:
+$(for ITEM in $CREATED_ISSUES; do echo "- $ITEM"; done)
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+```
+
+### Phase 5: 完了報告
+
+```markdown
+# /issue/backlog 完了
+
+**実行日時**: YYYY-MM-DD HH:MM
+
+---
+
+## 処理結果
+
+### ブロッカー解消Issue（/issue/unblock）
+
+| Issue | タイトル | Unblocks |
+|-------|---------|----------|
+| #70 | test(retriever): Add real FAISS E2E | BL-003, BL-005 |
+
+### 着手可能 → Issue化
+
+| BL ID | タイトル | 作成Issue |
+|-------|---------|----------|
+| BL-007 | ROS2 Executor | #71 |
+
+### backlog.md 更新
+
+- BL-007 を削除（Issue #71 へ移動）
+
+---
+
+## 残りのバックログ
+
+| BL ID | タイトル | 状態 |
+|-------|---------|------|
+| BL-001 | FeedbackMonitor | 👤 ユーザー確認待ち |
+| BL-002 | Notifier | ⏸️ BL-001依存 |
+| BL-003 | SONAR移行 | 🤖 Issue #70 で解消予定 |
+
+## 次のステップ
+
+1. `/issue/auto 70 71` で作成されたIssueを処理
+2. ユーザー確認項目は手動でテスト実施
+```
+
+## Options
+
+| オプション | 説明 |
+|-----------|------|
+| `--dry-run` | 分析のみ、Issue作成・backlog更新しない |
+| `--skip-unblock` | /issue/unblock をスキップ |
+| `--keep-in-backlog` | Issue作成するがbacklog.mdから削除しない |
+| `--comment-only` | 削除せず「Moved to #XX」コメントを残す |
+
+## Safety Features
+
+1. **dry-run モード**: 変更前に計画を確認可能
+2. **段階的処理**: unblock → Issue化 → 削除 の順序
+3. **コミット記録**: backlog.md の変更履歴が残る
+4. **移動コメント**: 削除時にIssue番号を記録（オプション）
+
+## Related Skills
+
+| スキル | 関係 |
+|-------|------|
+| `/issue/unblock` | Phase 1 で呼び出し |
+| `/issue/cycle` | 収束後に /issue/backlog を呼び出し |
+| `/issue/auto` | 作成されたIssueを自動処理 |

--- a/.claude/commands/issue/cycle.md
+++ b/.claude/commands/issue/cycle.md
@@ -25,28 +25,31 @@ argument-hint: [issue_ids...] [max_cycles]
 │                    /issue/cycle                             │
 ├─────────────────────────────────────────────────────────────┤
 │                                                             │
-│   Cycle 1:                                                  │
-│   ┌───────────────┐    ┌───────────────┐                   │
-│   │ /issue/auto   │ -> │ /issue/gaps   │                   │
-│   │ #5, #7        │    │ -> #10, #11   │  (新規Issue作成)   │
-│   └───────────────┘    └───────────────┘                   │
-│                              │                              │
-│                              v                              │
-│   Cycle 2:                                                  │
-│   ┌───────────────┐    ┌───────────────┐                   │
-│   │ /issue/auto   │ -> │ /issue/gaps   │                   │
-│   │ #10, #11      │    │ -> (なし)     │  (新規Issueなし)   │
-│   └───────────────┘    └───────────────┘                   │
-│                              │                              │
-│                              v                              │
-│   ┌───────────────────────────────────┐                    │
-│   │ Backlog Check                     │                    │
-│   │ docs/backlog.md をスキャン        │                    │
-│   │ -> 着手可能: BL-006              │  (Issue作成提案)    │
-│   └───────────────────────────────────┘                    │
-│                              │                              │
-│                              v                              │
-│   Convergence! (収束)                                       │
+│   ┌──────────────────── Main Loop ────────────────────┐    │
+│   │                                                    │    │
+│   │   Cycle 1:                                         │    │
+│   │   ┌───────────────┐    ┌───────────────┐          │    │
+│   │   │ /issue/auto   │ -> │ /issue/gaps   │          │    │
+│   │   │ #5, #7        │    │ -> #10, #11   │          │    │
+│   │   └───────────────┘    └───────────────┘          │    │
+│   │                              │                     │    │
+│   │                   新Issue? ──Yes──→ 次サイクルへ   │    │
+│   │                              │                     │    │
+│   │                             No                     │    │
+│   │                              ↓                     │    │
+│   │   ┌───────────────────────────────────┐           │    │
+│   │   │ /issue/backlog                    │           │    │
+│   │   │  1. /issue/unblock (ブロッカー解消)│           │    │
+│   │   │  2. 着手可能項目をIssue化         │           │    │
+│   │   │  3. backlog.mdから削除            │           │    │
+│   │   └───────────────────────────────────┘           │    │
+│   │                              │                     │    │
+│   │                   新Issue? ──Yes──→ 次サイクルへ   │    │
+│   │                              │                     │    │
+│   │                             No                     │    │
+│   └──────────────────────────────┼─────────────────────┘    │
+│                                  ↓                          │
+│                        完全収束 ✅                          │
 │                                                             │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -146,114 +149,34 @@ CYCLE_SNAPSHOT="cycle-${CYCLE_NUM}/$(date +%Y%m%d-%H%M%S)"
 git branch "$CYCLE_SNAPSHOT" HEAD
 ```
 
-### Phase Backlog: バックログチェック（収束後）
+### Phase Backlog: バックログ処理（収束後）
 
-Issue/gaps のサイクルが収束した後、`docs/backlog.md` をチェックして着手可能な項目がないか確認します。
-
-#### Step 1: バックログ読み込み
-
-```bash
-# docs/backlog.md を読み込み
-BACKLOG_FILE="docs/backlog.md"
-if [ -f "$BACKLOG_FILE" ]; then
-  BACKLOG_CONTENT=$(cat "$BACKLOG_FILE")
-else
-  echo "バックログファイルが存在しません"
-  BACKLOG_CONTENT=""
-fi
-```
-
-#### Step 2: 各項目の着手可否判定
+Issue/gaps のサイクルが収束した後、`/issue/backlog` を呼び出してバックログを処理します。
 
 ```
-Task(subagent_type="general-purpose", prompt="
-docs/backlog.md の各バックログ項目について、着手可能かどうかを判定してください。
-
-## 判定基準
-
-各項目の「後回しにした理由」を確認し、その理由が解消されているかをコードベースと照合します。
-
-例:
-- BL-001 (FeedbackMonitor): 「パイプライン全体を動かすことを優先」
-  → Phase 1/2 E2Eテストが完了していれば着手可能
-- BL-006 (duo-planner統合): 「duo-core単体で動作確認が取れてから」
-  → Phase 2 E2Eテストが完了していれば着手可能
-- BL-007 (ROS2 Executor): 「HTTPExecutorの実装が固まった後」
-  → HTTPExecutorが実装済みなら着手可能
-
-## 出力形式
-
-| BL ID | タイトル | 着手可否 | 理由 |
-|-------|---------|---------|------|
-| BL-001 | FeedbackMonitor | ✅ 可能 | Phase 2 E2E完了済み |
-| BL-002 | Notifier | ❌ 不可 | BL-001が先に必要 |
-| ...
-
-## 着手可能な項目がある場合
-
-Issue作成を提案:
-- タイトル案
-- 推奨ラベル
-- 依存関係
-")
+Skill(skill="issue/backlog")
 ```
 
-#### Step 3: Issue作成提案
+`/issue/backlog` は以下を実行します:
+1. `/issue/unblock` でブロッカー解消Issueを作成（自動解消可能なもののみ）
+2. ブロッカーがない項目をIssue化
+3. Issue化した項目を `docs/backlog.md` から削除
 
-着手可能な項目がある場合、ユーザーに確認を求めます:
+#### 継続判定
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│ バックログから着手可能な項目が見つかりました                │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│ ✅ BL-006: duo-planner との統合                            │
-│    理由: Phase 2 E2Eテストが完了し、duo-core単体動作確認済み│
-│                                                             │
-│ ✅ BL-007: ROS2 Executor                                   │
-│    理由: HTTPExecutor が実装済み                            │
-│                                                             │
-│ Issueを作成しますか？                                       │
-│ [はい、全て作成]                                            │
-│ [選択して作成]                                              │
-│ [いいえ、スキップ]                                          │
-└─────────────────────────────────────────────────────────────┘
-```
+`/issue/backlog` で新規Issueが作成された場合、メインループに戻ります:
 
-#### Step 4: Issue作成（承認時）
-
-```bash
-for BL_ITEM in $READY_BACKLOG_ITEMS; do
-  BL_ID=$(echo "$BL_ITEM" | jq -r '.id')
-  BL_TITLE=$(echo "$BL_ITEM" | jq -r '.title')
-  BL_DESCRIPTION=$(echo "$BL_ITEM" | jq -r '.description')
-  BL_CONSIDERATIONS=$(echo "$BL_ITEM" | jq -r '.considerations')
-
-  gh issue create \
-    --title "feat: ${BL_TITLE}" \
-    --body "## 概要
-
-${BL_DESCRIPTION}
-
-## 背景
-
-バックログ項目 ${BL_ID} より。
-\`/issue/cycle\` のバックログチェックで着手可能と判定されました。
-
-## 実装時の考慮点
-
-${BL_CONSIDERATIONS}
-
-## 関係
-- Backlog: ${BL_ID}
-
----
-*このIssueは /issue/cycle のバックログチェックにより自動生成されました*" \
-    --label "feature"
-
-  # バックログファイルに着手開始を記録
-  echo "<!-- Started: $(date +%Y-%m-%d) as Issue #XX -->" >> docs/backlog.md
-done
+```python
+if backlog_created_issues:
+    if cycle_count < max_cycles:
+        CURRENT_ISSUE_IDS = backlog_created_issues
+        continue  # メインループへ戻る
+    else:
+        print("最大サイクル到達。残りIssue:", backlog_created_issues)
+        break
+else:
+    print("完全収束しました")
+    break
 ```
 
 ### Phase Final: 完了報告
@@ -297,13 +220,14 @@ done
 | Cycle 1後 | cycle-1/20260318-121500 |
 | Cycle 2後 | cycle-2/20260318-123000 |
 
-## バックログチェック結果
+## バックログ処理結果（/issue/backlog）
 
-| BL ID | タイトル | 状態 | アクション |
-|-------|---------|------|-----------|
-| BL-006 | duo-planner統合 | ✅ 着手可能 | Issue #15 作成 |
-| BL-007 | ROS2 Executor | ✅ 着手可能 | Issue #16 作成 |
-| BL-001 | FeedbackMonitor | ❌ 未着手 | 依存: BL-002 |
+| 処理 | 結果 |
+|------|------|
+| ブロッカー解消Issue | #15, #16 |
+| 着手可能→Issue化 | BL-007 → #17 |
+| backlog.md更新 | BL-007 削除 |
+| 👤 ユーザー確認待ち | BL-001, BL-006（/qa/ask で通知済み） |
 
 ## ロールバック
 
@@ -380,8 +304,7 @@ git branch | grep "cycle-"
 | `--dry-run` | 実際の変更は行わず、計画のみ表示 |
 | `--no-confirm` | 確認プロンプトをスキップ |
 | `--resume BRANCH` | 指定ブランチから再開 |
-| `--skip-backlog` | バックログチェックをスキップ |
-| `--backlog-only` | バックログチェックのみ実行（サイクルなし） |
+| `--skip-backlog` | バックログ処理をスキップ |
 
 ## Natural Language Parsing
 
@@ -403,5 +326,8 @@ git branch | grep "cycle-"
 |-------|------|
 | `/issue/auto` | 各サイクルで呼び出し |
 | `/issue/gaps` | 各サイクルで呼び出し |
+| `/issue/backlog` | 収束後に呼び出し |
+| `/issue/unblock` | backlog 内部で使用 |
 | `/issue/scan` | gaps 内部で使用 |
 | `/issue/diff` | gaps 内部で使用 |
+| `/qa/ask` | unblock でユーザー確認必要項目を通知 |

--- a/.claude/commands/issue/unblock.md
+++ b/.claude/commands/issue/unblock.md
@@ -1,0 +1,265 @@
+---
+description: Analyze backlog blockers and create issues to resolve them (ブロッカー解消Issue作成)
+---
+
+# Issue Unblock
+
+バックログ (`docs/backlog.md`) のブロッカーを分析し、自動解消可能なものについてIssueを作成します。
+
+**注意**: このスキルはブロッカー解消のみを担当します。ブロッカーがない項目のIssue化は `/issue/backlog` が担当します。
+
+## Usage
+
+```
+/issue/unblock              # バックログ分析・Issue作成
+/issue/unblock --dry-run    # 分析のみ、Issue作成しない
+/issue/unblock --all        # ユーザー確認必要な項目も含めて報告
+```
+
+## Concept
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    /issue/unblock                           │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   docs/backlog.md                                           │
+│   ┌─────────────────────────────────────────────────────┐  │
+│   │ BL-001: FeedbackMonitor     → 👤 ユーザー確認必要   │  │
+│   │ BL-002: Notifier            → ⏸️ BL-001依存        │  │
+│   │ BL-003: SONAR移行           → 🤖 自動解消可能      │  │
+│   │ BL-007: ROS2 Executor       → 👤 ユーザー確認必要   │  │
+│   │ BL-008: duo publish         → 🤖 自動解消可能      │  │
+│   └─────────────────────────────────────────────────────┘  │
+│                              │                              │
+│                              ▼                              │
+│   ┌─────────────────────────────────────────────────────┐  │
+│   │ 🤖 自動解消可能なブロッカー                         │  │
+│   │                                                     │  │
+│   │ BL-003 ブロッカー: 実RAGテスト不足                  │  │
+│   │   → Issue: test(retriever): Add real FAISS E2E     │  │
+│   │                                                     │  │
+│   │ BL-008 ブロッカー: duo-ctl add 未実装               │  │
+│   │   → Issue: feat(cli): Implement duo-ctl add        │  │
+│   └─────────────────────────────────────────────────────┘  │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Workflow
+
+### Phase 1: バックログ読み込み
+
+```bash
+BACKLOG_FILE="docs/backlog.md"
+if [ ! -f "$BACKLOG_FILE" ]; then
+  echo "バックログファイルが存在しません"
+  exit 0
+fi
+```
+
+バックログをパースし、各項目を抽出:
+- ID (BL-XXX)
+- タイトル
+- 概要
+- 後回しにした理由
+- 実装時の考慮点
+
+### Phase 2: ブロッカー分類
+
+各バックログ項目の「後回しにした理由」を分析し、分類します。
+
+```
+Task(subagent_type="general-purpose", prompt="
+docs/backlog.md の各項目について、ブロッカーを分類してください。
+
+## 分類ルール
+
+### 🤖 自動解消可能
+以下のパターンに該当する場合:
+- 「実装」「コード追加」が必要 → コード実装で解消
+- 「テスト追加」が必要 → テスト実装で解消
+- 「Mockを実際の〜に置き換え」 → コード変更で解消
+- 「設計が完了してから」 → 設計ドキュメントがあれば解消
+
+### 👤 ユーザー確認必要
+以下のパターンに該当する場合:
+- 「実ハードウェア」「実サーバー」での確認が必要
+- 「実運用」「本番環境」での検証が必要
+- 「外部サービス」との連携確認が必要
+- ユーザーの判断・承認が必要
+
+### ⏸️ 依存待ち
+- 他のBL項目が前提条件として明記されている場合
+- 例: 「BL-001が先に必要」
+
+## 出力形式
+
+| BL ID | タイトル | 分類 | ブロッカー | 解消方法 |
+|-------|---------|------|-----------|----------|
+| BL-001 | ... | 👤/🤖/⏸️ | ... | ... |
+")
+```
+
+### Phase 3: Gap分析（自動解消可能な項目）
+
+🤖 自動解消可能と判定された項目について、具体的な不足を分析:
+
+```
+Task(subagent_type="general-purpose", prompt="
+以下のバックログ項目について、ブロッカー解消に必要な実装を特定してください。
+
+## 対象項目
+${AUTO_RESOLVABLE_ITEMS}
+
+## 分析内容
+1. 現在の実装状況を確認
+2. 不足している機能/テストを特定
+3. Issue作成用の情報を出力
+
+## 出力形式（各項目）
+- **BL ID**: BL-XXX
+- **ブロッカー**: 〜が不足
+- **Issue タイトル**: feat/test/fix(scope): description
+- **Issue 本文**: 概要、タスク、関係
+- **推奨ラベル**: feature/bug/chore
+")
+```
+
+### Phase 4: Issue作成
+
+自動解消可能なブロッカーに対してIssueを作成:
+
+```bash
+for BLOCKER in $AUTO_RESOLVABLE_BLOCKERS; do
+  BL_ID=$(echo "$BLOCKER" | jq -r '.bl_id')
+  ISSUE_TITLE=$(echo "$BLOCKER" | jq -r '.issue_title')
+  ISSUE_BODY=$(echo "$BLOCKER" | jq -r '.issue_body')
+  LABEL=$(echo "$BLOCKER" | jq -r '.label')
+
+  gh issue create \
+    --title "$ISSUE_TITLE" \
+    --body "## 概要
+
+${ISSUE_BODY}
+
+## 関係
+- Unblocks: ${BL_ID} in docs/backlog.md
+
+---
+*このIssueは /issue/unblock により自動生成されました*" \
+    --label "$LABEL"
+done
+```
+
+### Phase 5: ユーザー確認必要項目の通知
+
+👤 ユーザー確認必要と判定された項目がある場合、`/qa/ask` で通知します:
+
+```bash
+if [ -n "$USER_ACTION_REQUIRED_ITEMS" ]; then
+  # QA質問を投稿
+  /qa/ask --type deferred "バックログのユーザー確認待ち項目があります。
+
+以下の項目は実ハードウェア/実運用での確認が必要です:
+
+$(for ITEM in $USER_ACTION_REQUIRED_ITEMS; do
+  BL_ID=$(echo "$ITEM" | jq -r '.id')
+  BL_TITLE=$(echo "$ITEM" | jq -r '.title')
+  REQUIRED_ACTION=$(echo "$ITEM" | jq -r '.required_action')
+  echo "- **${BL_ID}**: ${BL_TITLE}"
+  echo "  必要なアクション: ${REQUIRED_ACTION}"
+done)
+
+確認完了後、該当項目のIssueを手動で作成してください。"
+fi
+```
+
+これにより、ユーザーが不在でも Slack/Discord で通知を受け取れます。
+
+### Phase 6: 完了報告
+
+```markdown
+# /issue/unblock 完了
+
+**実行日時**: YYYY-MM-DD HH:MM
+
+---
+
+## バックログ分析結果
+
+| BL ID | タイトル | 分類 | 状態 |
+|-------|---------|------|------|
+| BL-001 | FeedbackMonitor | 👤 ユーザー | 実ハードウェア確認待ち |
+| BL-002 | Notifier | ⏸️ 依存待ち | BL-001完了後 |
+| BL-003 | SONAR移行 | 🤖 自動 | Issue #XX 作成 |
+| BL-008 | duo publish | 🤖 自動 | Issue #XX 作成 |
+
+## 作成したIssue
+
+| Issue | タイトル | Unblocks |
+|-------|---------|----------|
+| #XX | test(retriever): Add real FAISS E2E tests | BL-003, BL-005 |
+| #XX | feat(cli): Implement duo-ctl add | BL-008 |
+
+## ユーザーアクション必要
+
+以下の項目はユーザーによる確認/テストが必要です:
+
+| BL ID | タイトル | 必要なアクション |
+|-------|---------|-----------------|
+| BL-001 | FeedbackMonitor | 実APIサーバーとの統合テスト実施 |
+| BL-007 | ROS2 Executor | HTTPExecutorの実運用検証 |
+
+---
+
+## 次のステップ
+
+1. 作成されたIssueを `/issue/auto` で処理
+2. ユーザーアクション項目を手動で確認
+3. 確認完了後、該当BL項目のIssueを手動作成
+```
+
+## Options
+
+| オプション | 説明 |
+|-----------|------|
+| `--dry-run` | 分析のみ、Issue作成しない |
+| `--all` | ユーザー確認必要な項目も詳細報告 |
+| `--create-all` | ユーザー確認必要な項目もIssue作成（確認Issueとして） |
+
+## ブロッカー分類パターン
+
+### 🤖 自動解消可能
+
+| パターン | 解消方法 |
+|---------|----------|
+| 「〜の実装が必要」 | コード実装 |
+| 「テストが不足」「Mockを置き換え」 | テスト追加 |
+| 「設計完了後」+ 設計ドキュメント存在 | 実装開始可能 |
+| 「〜が固まった後」+ 実装完了 | 実装開始可能 |
+
+### 👤 ユーザー確認必要
+
+| パターン | 理由 |
+|---------|------|
+| 「実ハードウェア」「実サーバー」 | 物理環境が必要 |
+| 「実運用」「本番環境」 | 本番相当環境が必要 |
+| 「外部サービス連携」 | 外部依存 |
+| 「ユーザー判断」「ビジネス判断」 | 人間の決定が必要 |
+
+## Safety Features
+
+1. **dry-run モード**: Issue作成前に計画を確認可能
+2. **ユーザー確認項目の分離**: 自動処理と手動処理を明確に分離
+3. **依存関係考慮**: 依存BLが未完了の項目はスキップ
+4. **Unblocks 関係記録**: 作成IssueにどのBL項目を解消するか記録
+
+## Related Skills
+
+| スキル | 関係 |
+|-------|------|
+| `/issue/backlog` | /issue/unblock を呼び出した後、ブロッカーなし項目をIssue化 |
+| `/issue/cycle` | 収束後に /issue/backlog を呼び出し（間接的に unblock も実行） |
+| `/issue/gaps` | Gap分析ロジックを共有 |
+| `/issue/auto` | 作成されたIssueを自動処理 |

--- a/claude-san
+++ b/claude-san
@@ -12,10 +12,10 @@ CLAUDE_CMD="claude --dangerously-skip-permissions $CLAUDE_ARGS"
 echo "新規セッション作成: $SESSION_NAME"
 [ -n "$CLAUDE_ARGS" ] && echo "Claude args: $CLAUDE_ARGS"
 
-tmux new-session -d -s "$SESSION_NAME"
-tmux send-keys -t "$SESSION_NAME" "$CLAUDE_CMD" Enter
-tmux split-window -h -l 50% -t "$SESSION_NAME"
-tmux send-keys -t "$SESSION_NAME" 'autoclaude' Enter
+# tmuxセッションを作成し、bash -icでシェル環境を維持しつつ直接起動
+# これにより元のbashが死んでもtmuxセッションは生き残る
+tmux new-session -d -s "$SESSION_NAME" "bash -ic '$CLAUDE_CMD'"
+tmux split-window -h -l 50% -t "$SESSION_NAME" "bash -ic 'autoclaude'"
 
 # バックグラウンドで5秒後に'a'キーを送信（autoclaudeの起動を待つ）
 (sleep 5 && tmux send-keys -t "$SESSION_NAME":0.1 'a') &


### PR DESCRIPTION
## 変更概要

### 新規スキル

| スキル | 説明 |
|-------|------|
| `/issue/backlog` | バックログ処理（unblock呼び出し → ブロッカーなし項目をIssue化 → backlog.mdから削除） |
| `/issue/unblock` | バックログのブロッカー分析・自動解消Issue作成・ユーザー確認必要項目を `/qa/ask` で通知 |

### 更新

| ファイル | 変更内容 |
|---------|---------|
| `/issue/cycle` | 収束後に `/issue/backlog` を呼び出し、新Issue作成時はサイクル継続 |
| `claude-san` | tmuxセッションの安定性改善（`bash -ic` 使用で親bash終了時もセッション維持） |

## 変更の意図

1. **バックログの自動処理**: 手動でバックログを確認してIssue化する手間を削減
2. **ブロッカーの可視化**: 自動解消可能なブロッカーとユーザー確認必要なブロッカーを分類
3. **完全な自動化サイクル**: `/issue/cycle` でIssue処理 → Gap検出 → バックログ処理 までを一貫して実行

## 影響範囲

- 新規スキルの追加のため、既存機能への影響なし
- `/issue/cycle` のオプション `--skip-backlog` で従来動作も可能

## フロー図

```
/issue/cycle
  → /issue/auto → /issue/gaps → (繰り返し)
  → /issue/backlog
      → /issue/unblock (ブロッカー解消)
      → Issue化 + backlog.md更新
  → 新Issue? → Yes → サイクル継続
  → 完全収束 ✅
```

---
*This PR was created via `/template/contribute` command from duo-core project.*