### PR TITLE
fix: worktree作成先パスを .worktrees/ に統一

### DIFF
--- a/.claude/commands/issue/gaps.md
+++ b/.claude/commands/issue/gaps.md
@@ -142,7 +142,7 @@ for NEW_ISSUE in $NEW_ISSUE_CANDIDATES; do
       BRANCH_NAME=$(gh issue view $ISSUE_NUM --json body -q '.body' | grep -oP 'feature/\d+-\S+' | head -1)
       if [ -n "$BRANCH_NAME" ]; then
         # worktreeの変更ファイルを確認
-        MODIFIED_FILES=$(git -C worktrees/issue${ISSUE_NUM} diff --name-only 2>/dev/null || echo "")
+        MODIFIED_FILES=$(git -C .worktrees/issue${ISSUE_NUM} diff --name-only 2>/dev/null || echo "")
 
         # 新規Issueが同じファイルに影響するかチェック
         for FILE in $NEW_ISSUE_TARGET_FILES; do

--- a/.claude/commands/issue/start.md
+++ b/.claude/commands/issue/start.md
@@ -26,7 +26,7 @@ argument-hint: [short-description]
    - 例: `feature/5-add-dataset-loader`, `survey/3-related-work`
 
 3. **Worktree を作成**
-   - パス: `../project-name-issueN`
+   - パス: `.worktrees/issueN`
    - ブランチと連携
 
 4. **作業開始の準備**
@@ -91,8 +91,7 @@ Worktree とブランチを作成:
 ISSUE_ID=$(gh issue list --limit 1 --json number --jq '.[0].number')
 DESCRIPTION=$(echo "$TASK_DESCRIPTION" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
 REPO_ROOT=$(git rev-parse --show-toplevel)
-REPO_NAME=$(basename "$REPO_ROOT")
-WORKTREE_PATH="../${REPO_NAME}-issue${ISSUE_ID}"
+WORKTREE_PATH="${REPO_ROOT}/.worktrees/issue${ISSUE_ID}"
 
 git worktree add "$WORKTREE_PATH" -b "${BRANCH_PREFIX}/${ISSUE_ID}-${DESCRIPTION}"
 ```

--- a/install.sh
+++ b/install.sh
@@ -200,7 +200,7 @@ fi
 # Handle .gitignore
 if [[ -f ".gitignore" ]]; then
     GITIGNORE_ENTRIES=(
-        "worktrees/"
+        ".worktrees/"
         "data/shared/**"
         "!data/shared/.gitkeep"
         "data/local/"


### PR DESCRIPTION
## Summary

- worktree 作成先がプロジェクト外（`../`）になっていたのを `.worktrees/` に修正
- `install.sh` の `.gitignore` エントリも `worktrees/` → `.worktrees/` に統一
- `issue/gaps.md` のパス参照も `.worktrees/` に修正

## Why

プロジェクト外への worktree 作成は：
- コンテナ環境でディレクトリ権限エラーを引き起こす
- `.gitignore` で管理できない
- ドキュメントと実装の不整合が生じていた

## Changed files

| File | Change |
|------|--------|
| `.claude/commands/issue/start.md` | `../${REPO_NAME}-issueN` → `.worktrees/issueN` |
| `.claude/commands/issue/gaps.md` | `worktrees/` → `.worktrees/` |
| `install.sh` | `.gitignore` entry `worktrees/` → `.worktrees/` |

## Impact

テンプレートを使用する全プロジェクトで worktree がプロジェクト内に作成されるようになる。既存プロジェクトは `.gitignore` の手動更新が必要。

---
*This PR was created via `/template/contribute` command.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)