### PR TITLE
fix(devcontainer): add overrideCommand and sleep infinity for NVIDIA entrypoint

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -8,6 +8,7 @@
   "workspaceFolder": "/workspace",
 
   // --- [Template] devcontainer 固有の共通設定 ---
+  "overrideCommand": false,
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "mounts": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     ulimits:
       memlock: -1
       stack: 67108864
+    # Note: NVIDIA entrypoint sets CMD=null, so keep-alive is required.
+    # See: https://github.com/devcontainers/features/issues/954
+    command: ["sleep", "infinity"]
     volumes:
       - ..:/workspace:cached
       - ${HOME}/.gitconfig:/home/vscode/.gitconfig:cached

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -8,6 +8,7 @@
   "workspaceFolder": "/workspace",
 
   // --- [Template] devcontainer 固有の共通設定 ---
+  "overrideCommand": false,
   "remoteUser": "vscode",
   "updateRemoteUserUID": true,
   "mounts": [


### PR DESCRIPTION
## Summary
- Add `overrideCommand: false` to cpu and gpu `devcontainer.json`
- Add `command: ["sleep", "infinity"]` to `docker-compose.yml`

## Problem
NVIDIA base images (e.g., `nvcr.io/nvidia/pytorch:24.12-py3`) set `CMD=null` in their entrypoint, causing containers to exit immediately after startup. The `docker-outside-of-docker` feature also forces `command: []`, compounding the issue.

Reference: https://github.com/devcontainers/features/issues/954

## Impact
Without this fix, devcontainers using NVIDIA GPU base images exit immediately. This was independently discovered and fixed in both PushVoice and duo-core downstream projects.

---
*This PR was created via `/template/contribute` command.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)