### PR TITLE
chore(claude): 「指示があったときのみコミット」ルールを削除（#81）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -121,15 +121,13 @@ data/shared/experiments/
 
 ## コミットのルール
 
-- **指示があったときのみコミットする**
-  - 自動的にコミットせず、明示的な指示を待つ
-  - コミットメッセージには必ず Issue を参照: `Fixes #ISSUE_ID` または `Refs #ISSUE_ID`
-  - Conventional Commits 形式を推奨:
-    - `feat(scope): description` - 新機能
-    - `fix(scope): description` - バグ修正
-    - `docs(scope): description` - ドキュメント
-    - `refactor(scope): description` - リファクタリング
-    - `test(scope): description` - テスト追加
+- コミットメッセージには必ず Issue を参照: `Fixes #ISSUE_ID` または `Refs #ISSUE_ID`
+- Conventional Commits 形式を推奨:
+  - `feat(scope): description` - 新機能
+  - `fix(scope): description` - バグ修正
+  - `docs(scope): description` - ドキュメント
+  - `refactor(scope): description` - リファクタリング
+  - `test(scope): description` - テスト追加
 
 ---
 
@@ -288,9 +286,8 @@ torch.hub.set_dir("data/shared/models")
 1. **常に worktree を使用**: メインディレクトリで直接作業しない
 2. **Issue なしで作業しない**: すべてのタスクは Issue から開始
 3. **進捗は Issue に記録**: コミット前に必ず報告
-4. **明示的指示を待つ**: 自動コミットはしない
-5. **ルールは絶対**: このファイルに記載された全てのルール、スキルで定義されたワークフローは必ず従う
-6. **省略・逸脱する前に確認**: ルールから外れる行為をする場合は、事前に一言ユーザーに確認を取る。自己判断で「不要」「単純だから省略」と決めない
+4. **ルールは絶対**: このファイルに記載された全てのルール、スキルで定義されたワークフローは必ず従う
+5. **省略・逸脱する前に確認**: ルールから外れる行為をする場合は、事前に一言ユーザーに確認を取る。自己判断で「不要」「単純だから省略」と決めない
 
 ---
 


### PR DESCRIPTION
## 概要

CLAUDE.md の「指示があったときのみコミットする」ルールは古い指示であり、現在は不要になったため削除。

## 変更

- `## コミットのルール` から「指示があったときのみコミットする」「自動的にコミットせず、明示的な指示を待つ」を削除し、配下の箇条書きを1階層繰り上げ
- `## 重要な注意事項` から項目4「明示的指示を待つ: 自動コミットはしない」を削除し、項目5・6 を繰り上げ

## 維持したもの

- コミットメッセージの Issue 参照ルール（`Fixes #ISSUE_ID` / `Refs #ISSUE_ID`）
- Conventional Commits 形式の推奨

Closes #81