### PR TITLE
fix: worktree の .git 参照を相対パス化（#77）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,7 +29,7 @@
    - 並行タスクでブランチがコンタミネーション（混入）しないよう、**必ず worktree を作成**して作業する
    - Worktree 作成例:
      ```bash
-     git worktree add worktrees/issue5 feature/5-add-dataset-loader
+     git worktree add --relative-paths worktrees/issue5 feature/5-add-dataset-loader
      cd worktrees/issue5
      ```
    - 複数の Issue を並行して進める場合、それぞれ独立した worktree で作業する
@@ -188,9 +188,41 @@ data/shared/experiments/
 
 ```bash
 # 新しい Issue #N のブランチと worktree を作成
-git worktree add worktrees/issueN feature/N-description
+git worktree add --relative-paths worktrees/issueN feature/N-description
 cd worktrees/issueN
 ```
+
+### ★ `--relative-paths` が必須な理由
+
+`git worktree add` は既定で `.git` 参照を**絶対パス**で2箇所に書き込む:
+
+```
+worktrees/issueN/.git        → gitdir: <絶対パス>/.git/worktrees/issueN
+.git/worktrees/issueN/gitdir → <絶対パス>/worktrees/issueN/.git
+```
+
+devcontainer はリポジトリを `/workspace` にマウントするため、**ホストとコンテナで絶対パスが一致しない**。
+結果として **worktree を作成した側の環境でしか git / gh が動かない**（双方向に壊れる）。
+
+| 作成場所 | 書き込まれるパス | 壊れる環境 |
+|---|---|---|
+| devcontainer 内 | `/workspace/...` | ホスト |
+| ホスト | `/Users/...` | devcontainer 内 |
+
+`--relative-paths` を付けると相対パスで書かれ、両環境から解決できる（git 2.48 以降）。
+
+`scripts/configure-worktree-paths.sh` が `worktree.useRelativePaths=true` を設定するため、
+通常は自動で有効になる（devcontainer 起動時と `/worktree-init` 実行時）。
+上記のコマンド例で明示しているのは、設定が無い環境でも安全にするため。
+
+### 既存の壊れた worktree を復旧する
+
+```bash
+# 現在の環境から見た正しいパスに書き換える
+git worktree repair
+```
+
+**実行した環境でのみ有効**なので、恒久対策は相対パス化のほう。
 
 ### 並行作業の例
 

--- a/.claude/skills/issue-gaps/SKILL.md
+++ b/.claude/skills/issue-gaps/SKILL.md
@@ -142,7 +142,7 @@ for NEW_ISSUE in $NEW_ISSUE_CANDIDATES; do
       BRANCH_NAME=$(gh issue view $ISSUE_NUM --json body -q '.body' | grep -oP 'feature/\d+-\S+' | head -1)
       if [ -n "$BRANCH_NAME" ]; then
         # worktreeの変更ファイルを確認
-        MODIFIED_FILES=$(git -C .worktrees/issue${ISSUE_NUM} diff --name-only 2>/dev/null || echo "")
+        MODIFIED_FILES=$(git -C worktrees/issue${ISSUE_NUM} diff --name-only 2>/dev/null || echo "")
 
         # 新規Issueが同じファイルに影響するかチェック
         for FILE in $NEW_ISSUE_TARGET_FILES; do

--- a/.claude/skills/issue-start/SKILL.md
+++ b/.claude/skills/issue-start/SKILL.md
@@ -26,7 +26,7 @@ argument-hint: [short-description]
    - 例: `feature/5-add-dataset-loader`, `survey/3-related-work`
 
 3. **Worktree を作成**
-   - パス: `.worktrees/issueN`
+   - パス: `worktrees/issueN`
    - ブランチと連携
 
 4. **作業開始の準備**
@@ -91,9 +91,9 @@ Worktree とブランチを作成:
 ISSUE_ID=$(gh issue list --limit 1 --json number --jq '.[0].number')
 DESCRIPTION=$(echo "$TASK_DESCRIPTION" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
 REPO_ROOT=$(git rev-parse --show-toplevel)
-WORKTREE_PATH="${REPO_ROOT}/.worktrees/issue${ISSUE_ID}"
+WORKTREE_PATH="${REPO_ROOT}/worktrees/issue${ISSUE_ID}"
 
-git worktree add "$WORKTREE_PATH" -b "${BRANCH_PREFIX}/${ISSUE_ID}-${DESCRIPTION}"
+git worktree add --relative-paths "$WORKTREE_PATH" -b "${BRANCH_PREFIX}/${ISSUE_ID}-${DESCRIPTION}"
 ```
 
 Issue に開始報告:

--- a/.claude/skills/worktree-init/init.sh
+++ b/.claude/skills/worktree-init/init.sh
@@ -3,4 +3,10 @@
 # Calls scripts/init-data.sh
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+# worktree の .git 参照を相対パス化（ホスト/コンテナ間でパスが異なるため）
+if [ -x "$REPO_ROOT/scripts/configure-worktree-paths.sh" ]; then
+  "$REPO_ROOT/scripts/configure-worktree-paths.sh" || true
+fi
+
 exec "$REPO_ROOT/scripts/init-data.sh" "$@"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -36,3 +36,8 @@ fi
 
 # claude-san symlink
 sudo ln -sf "$(pwd)/claude-san" /usr/local/bin/claude-san
+
+# worktree の .git 参照を相対パス化（ホスト/コンテナ間でパスが異なるため）
+if [ -x ./scripts/configure-worktree-paths.sh ]; then
+  ./scripts/configure-worktree-paths.sh || true
+fi

--- a/scripts/configure-worktree-paths.sh
+++ b/scripts/configure-worktree-paths.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ============================================================
+# worktree の .git 参照を相対パスにする設定
+# [Template] research-project-template 由来
+# ============================================================
+#
+# 背景:
+#   git worktree add は既定で .git 参照を「絶対パス」で 2 箇所に書き込む。
+#     worktrees/issueN/.git        → gitdir: <絶対パス>/.git/worktrees/issueN
+#     .git/worktrees/issueN/gitdir → <絶対パス>/worktrees/issueN/.git
+#
+#   devcontainer はリポジトリを /workspace にマウントするため、ホストとコンテナで
+#   絶対パスが一致しない。結果として **worktree を作成した側の環境でしか git / gh が
+#   動かない**（双方向に壊れる）。
+#
+#   worktree.useRelativePaths=true にすると相対パスで書かれ、両環境から解決できる。
+#
+# 要件:
+#   git 2.48 以降（--relative-paths / worktree.useRelativePaths の対応バージョン）
+#
+# 呼び出し元:
+#   - .devcontainer/post-create.sh （コンテナ側）
+#   - scripts/init-data.sh         （ホスト側 /worktree-init 経由）
+
+set -uo pipefail
+
+git rev-parse --show-toplevel >/dev/null 2>&1 || {
+  echo "[worktree-paths] git リポジトリではないためスキップ"
+  exit 0
+}
+
+GIT_VERSION=$(git --version | awk '{print $3}')
+GIT_MAJOR=${GIT_VERSION%%.*}
+GIT_REST=${GIT_VERSION#*.}
+GIT_MINOR=${GIT_REST%%.*}
+
+if [ "$GIT_MAJOR" -gt 2 ] || { [ "$GIT_MAJOR" -eq 2 ] && [ "$GIT_MINOR" -ge 48 ]; }; then
+  git config worktree.useRelativePaths true
+  echo "[worktree-paths] worktree.useRelativePaths=true を設定（git ${GIT_VERSION}）"
+else
+  echo "[worktree-paths] WARNING: git ${GIT_VERSION} は worktree.useRelativePaths 未対応（2.48 以降が必要）"
+  echo "[worktree-paths] ホストと devcontainer で worktree を共有すると git / gh が動きません。"
+  echo "[worktree-paths] 各環境で 'git worktree repair' を実行して回避してください。"
+fi
+
+# 既存 worktree の絶対パスをこの環境向けに修復する。
+# 相対パス化されていない過去の worktree を救済するため、設定の成否に関わらず実行する。
+if [ -d "$(git rev-parse --git-common-dir)/worktrees" ]; then
+  git worktree repair >/dev/null 2>&1 && echo "[worktree-paths] 既存 worktree の参照を修復しました"
+fi
+
+exit 0


### PR DESCRIPTION
## 問題

`git worktree add` は `.git` 参照を**絶対パス**で2箇所に書き込む。devcontainer は `/workspace`、ホストは `/Users/...` にマウントされるため、**worktree を作成した側の環境でしか git / gh が動かない**（双方向に破損）。

| 作成場所 | 壊れる環境 |
|---|---|
| devcontainer 内 | ホスト |
| ホスト | devcontainer 内 |

CLAUDE.md が worktree 使用を必須ルールとしているため、ワークフローの根幹に影響していた。

## 修正

- **`scripts/configure-worktree-paths.sh` を追加** — `worktree.useRelativePaths=true` を設定（git 2.48+）。未対応版では警告し `git worktree repair` を案内。既存 worktree も repair で救済
- **post-create.sh（コンテナ）と worktree-init/init.sh（ホスト）から呼び出し** — ロジックは1箇所に集約
- **`git worktree add` 全箇所に `--relative-paths` を明示**
- **CLAUDE.md に理由・影響表・復旧手順を追記**

## 併せて修正: パス表記の不一致

`issue-start` / `issue-gaps` が `.worktrees/`（ドット付き）を使っていたが、`.gitignore` と CLAUDE.md は `worktrees/`（ドット無し）。**スキルに従うと gitignore が効かず worktree 内の全ファイルが git status を汚染していた。**

## 検証

- `--relative-paths` で `gitdir: ../../.git/worktrees/<name>` になることを実地確認
- `.worktrees` 参照の残存ゼロ
- quality-check.sh exit 0

Closes #77