### PR TITLE
feat: サブエージェントのモデル割当を role 単位で変数制御にする（#71）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,7 @@
 | `issue-hierarchy.md` | epic / task / issue の3層構造、既定の task 構成、ゴールの不変性 |
 | `labels.md` | ラベル運用ルール、GitHub ネイティブ sub-issue |
 | `skills.md` | スキル一覧（層ごと） |
+| `model-policy.md` | サブエージェントのモデル割当（role → model）、枠上限時のフォールバック |
 | `git-workflow.md` | コミット・PR・Git Worktree 管理 |
 | `experiment-discipline.md` | ネガティブ結論の扱い、matched-engineering |
 | `dev-guidelines.md` | コード品質、研究ノート、ブランチ命名 |

--- a/.claude/agents/auto-reviewer.md
+++ b/.claude/agents/auto-reviewer.md
@@ -1,3 +1,11 @@
+---
+name: auto-reviewer
+description: review-spec の結果に対しユーザーの代理で判断を行う。goal の書き換えを禁止と判定する
+role: abstract-review
+model: inherit  # 実際の割当は .claude/model-policy.json の role で決まる
+tools: Read, Grep, Glob, Bash
+---
+
 # Auto-Reviewer Agent
 
 `/task-run` 実行時に review-spec の結果に対してユーザーの代理で判断を行うエージェント。

--- a/.claude/agents/issue-diff-analyzer.md
+++ b/.claude/agents/issue-diff-analyzer.md
@@ -1,3 +1,11 @@
+---
+name: issue-diff-analyzer
+description: 単一 Issue と HEAD 実装の乖離を分析する
+role: verification
+model: inherit  # 実際の割当は .claude/model-policy.json の role で決まる
+tools: Read, Grep, Glob, Bash
+---
+
 # Issue Diff Analyzer Agent
 
 `/issue/diff` 実行時に単一IssueとHEAD実装の乖離を分析するエージェント。

--- a/.claude/agents/issue-scanner.md
+++ b/.claude/agents/issue-scanner.md
@@ -1,3 +1,11 @@
+---
+name: issue-scanner
+description: 全 Issue の状態を走査・分類する
+role: mechanical
+model: inherit  # 実際の割当は .claude/model-policy.json の role で決まる
+tools: Read, Grep, Glob, Bash
+---
+
 # Issue Scanner Agent
 
 `/issue/scan` 実行時に全Issueの状態を分析するエージェント。

--- a/.claude/model-policy.json
+++ b/.claude/model-policy.json
@@ -1,0 +1,51 @@
+{
+  "$comment": [
+    "エージェント呼び出しのモデル割当。役割(role)→モデルの対応を1箇所で定義する。",
+    "スキル側は具体的なモデル名を書かず role 名で参照すること。",
+    "解決は scripts/resolve-model.sh が行う。",
+    "利用枠の上限に当たった場合は disabled に追加すれば fallback に降りる。"
+  ],
+  "roles": {
+    "planning": {
+      "description": "実装計画の策定、タスク分解、設計の骨子",
+      "primary": "fable",
+      "fallback": [
+        "opus",
+        "sonnet"
+      ]
+    },
+    "abstract-review": {
+      "description": "仕様レビュー、設計レビュー、代理判断など抽象度の高い判断",
+      "primary": "fable",
+      "fallback": [
+        "opus",
+        "sonnet"
+      ]
+    },
+    "implementation": {
+      "description": "コードの実装・修正。具体性と確実性が要る",
+      "primary": "opus",
+      "fallback": [
+        "sonnet"
+      ]
+    },
+    "verification": {
+      "description": "実装と仕様の突き合わせ、コードレビュー、整合性チェック",
+      "primary": "opus",
+      "fallback": [
+        "sonnet"
+      ]
+    },
+    "mechanical": {
+      "description": "集計・分類・フォーマット確認など判断の幅が小さい作業",
+      "primary": "haiku",
+      "fallback": [
+        "sonnet"
+      ]
+    }
+  },
+  "disabled": [],
+  "overrides": {
+    "$comment": "role ごとにプロジェクト固有の上書きをする場合はここに書く。例: \"implementation\": \"sonnet\""
+  }
+}

--- a/.claude/rules/model-policy.md
+++ b/.claude/rules/model-policy.md
@@ -1,0 +1,79 @@
+## モデル割当（role → model）
+
+サブエージェントに使うモデルは、**呼び出し箇所（call-site）の役割**で決まります。
+Issue のラベルや層ではありません。**1つの issue の中に抽象と具体が混在する**ためです。
+
+### 定義の所在
+
+| ファイル | 役割 |
+|---|---|
+| `.claude/model-policy.json` | **role → モデルの対応。単一情報源** |
+| `scripts/resolve-model.sh` | role からモデル名を解決する |
+
+**スキルに具体的なモデル名を書かないこと。** role 名で参照します。
+
+```bash
+MODEL=$(bash scripts/resolve-model.sh abstract-review)
+```
+
+### role の一覧
+
+| role | 内容 | 既定 |
+|---|---|---|
+| `planning` | 実装計画の策定、タスク分解、設計の骨子 | fable |
+| `abstract-review` | 仕様レビュー、設計レビュー、代理判断 | fable |
+| `implementation` | コードの実装・修正 | opus |
+| `verification` | 実装と仕様の突き合わせ、コードレビュー、整合性チェック | opus |
+| `mechanical` | 集計・分類・フォーマット確認 | haiku |
+
+未定義の role は `inherit`（セッションのモデルを継承）になります。
+
+### call-site の割当
+
+| 呼び出し箇所 | role |
+|---|---|
+| `/review-spec` の各サブエージェント | `abstract-review` |
+| `auto-reviewer` の代理判断 | `abstract-review` |
+| `/task-run` Step 2（実装） | `implementation` |
+| `/task-run` Step 4-2（仕様整合性チェック） | `verification` |
+| `/review` の設計観点 | `abstract-review` |
+| `/review` のコード観点 | `verification` |
+| `/issue-scan` の集計 | `mechanical` |
+| `/issue-diff` の乖離分析 | `verification` |
+| `/issue-gaps` の集計 | `mechanical` |
+| `/review-integrity` の探索 | `verification` |
+
+### 利用枠の上限に当たったとき
+
+`disabled` に追加すると、そのモデルを primary に持つ role は **fallback に降ります**。
+
+```bash
+bash scripts/resolve-model.sh --disable fable   # 枠を使い切ったとき
+bash scripts/resolve-model.sh --enable  fable   # 復帰したとき
+bash scripts/resolve-model.sh --list            # 現在の解決結果を確認
+```
+
+一時的に切り替えるだけなら環境変数でも指定できます（設定ファイルより優先）。
+
+```bash
+MODEL_POLICY_DISABLE=fable,opus /task-run #101
+```
+
+fallback は多段です。`fable → opus → sonnet` の順に降り、全て無効なら `inherit` になります。
+
+### プロジェクト固有の上書き
+
+`.claude/model-policy.json` の `overrides` に書きます。
+
+```json
+"overrides": { "implementation": "sonnet" }
+```
+
+### 注意
+
+- **メインのモデルを切り替えても、role が定義されていない呼び出しは追従します。**
+  planning を fable にしたい場合でも、実装の call-site が `implementation` role で
+  呼ばれていれば opus のままになります
+- エージェント定義（`.claude/agents/*.md`）の frontmatter には `role` を書きます。
+  `model:` は `inherit` のままにし、実際の割当は本ポリシーで決めます
+  （モデル名を2箇所に書かないため）

--- a/.claude/skills/review-spec/SKILL.md
+++ b/.claude/skills/review-spec/SKILL.md
@@ -88,7 +88,7 @@ ls $SPEC_FILE 2>/dev/null
 
 #### 3-1. 実現性レビュー（Feasibility Review）
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 レビュー観点：
 - **既存資産の再利用**: 同様の機能・パターンが既に存在するか。流用・拡張できるか
@@ -136,7 +136,7 @@ Task tool で `subagent_type=general-purpose` を使用。
 
 #### 3-2. 品質レビュー（Quality Review）
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 レビュー観点：
 - **処理フロー**: 入力→処理→出力の流れは明確か。分岐・ループの条件は定義されているか
@@ -213,7 +213,7 @@ stateDiagram-v2
 
 #### 3-3. 設計レビュー（Design Review）
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 レビュー観点：
 - **単一責任原則**: 1機能が複数責務を持っていないか
@@ -252,7 +252,7 @@ Task tool で `subagent_type=general-purpose` を使用。
 
 #### 3-4. Fallback計画チェッカー（Fallback Planning Check）
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 レビュー観点：
 仕様・状態遷移から、else/default/catchケースを抽出し、それぞれが：
@@ -290,7 +290,7 @@ Task tool で `subagent_type=general-purpose` を使用。
 
 #### 3-5. 妥当性検証チェッカー（Validation Checker）
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 **WebSearch ツールを使用して、仕様の各項目の妥当性を検証します。**
 
@@ -336,7 +336,7 @@ Task tool で `subagent_type=general-purpose` を使用。
 
 **GUI/フロントエンド実装の場合のみ実行**。
 
-Task tool で `subagent_type=general-purpose` を使用。
+Task tool で `subagent_type=general-purpose` を使用。モデルは `bash scripts/resolve-model.sh abstract-review` で解決する。
 
 発動条件（いずれかに該当）：
 - ファイルパターン: `**/*.html`, `**/*.css`, `**/*.js`, `**/templates/**`, `**/static/**`

--- a/.claude/skills/task-run/SKILL.md
+++ b/.claude/skills/task-run/SKILL.md
@@ -142,7 +142,7 @@ review-spec はユーザーとの対話ではなく**セルフチェック**で�
 3. **auto-reviewer による代理判断**
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Task(subagent_type="general-purpose", model="$(bash scripts/resolve-model.sh abstract-review)", prompt="
 あなたは auto-reviewer エージェントです。
 .claude/agents/auto-reviewer.md の定義に従って判断してください。
 
@@ -173,7 +173,7 @@ ${REVIEW_SPEC_RESULT}
 #### Step 2: 実装
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Task(subagent_type="general-purpose", model="$(bash scripts/resolve-model.sh implementation)", prompt="
 Issue #${ISSUE_ID} の実装を行ってください。
 
 ## 親 task の goal（この範囲を超えないこと）
@@ -222,7 +222,7 @@ fi
 #### Step 4-2: 仕様整合性チェック
 
 ```
-Task(subagent_type="general-purpose", prompt="
+Task(subagent_type="general-purpose", model="$(bash scripts/resolve-model.sh verification)", prompt="
 実装が仕様ファイルに適合しているか検証してください。
 
 ## 検証項目

--- a/scripts/resolve-model.sh
+++ b/scripts/resolve-model.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# ============================================================
+# role → モデル名の解決
+# [Template] research-project-template 由来
+# ============================================================
+#
+# .claude/model-policy.json を読み、role に対応するモデル名を返す。
+# スキル側は具体的なモデル名を書かず、本スクリプト経由で解決すること。
+#
+# Usage:
+#   MODEL=$(bash scripts/resolve-model.sh abstract-review)
+#   Task(subagent_type=..., model="$MODEL", prompt=...)
+#
+#   bash scripts/resolve-model.sh --list       # 全 role の解決結果を表示
+#   bash scripts/resolve-model.sh --disable fable   # 枠上限時に一時的に無効化
+#   bash scripts/resolve-model.sh --enable fable
+#
+# 利用枠の上限に当たった場合:
+#   disabled に追加すると、その モデル を primary に持つ role は fallback に降りる。
+#   環境変数 MODEL_POLICY_DISABLE でも指定できる（カンマ区切り。設定ファイルより優先）。
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+POLICY="$REPO_ROOT/.claude/model-policy.json"
+
+[ -f "$POLICY" ] || { echo "inherit"; exit 0; }   # ポリシーが無ければセッションのモデルを継承
+command -v jq >/dev/null 2>&1 || { echo "inherit"; exit 0; }
+
+disabled_list() {
+  local from_file from_env
+  from_file=$(jq -r '.disabled[]?' "$POLICY" 2>/dev/null | tr '\n' ',')
+  from_env="${MODEL_POLICY_DISABLE:-}"
+  echo "${from_file},${from_env}"
+}
+
+is_disabled() {
+  local m="$1"
+  echo ",$(disabled_list)," | grep -q ",${m},"
+}
+
+resolve() {
+  local role="$1"
+
+  # プロジェクト固有の上書きが最優先
+  local ov
+  ov=$(jq -r --arg r "$role" '.overrides[$r] // empty' "$POLICY" 2>/dev/null)
+  if [ -n "$ov" ] && ! is_disabled "$ov"; then echo "$ov"; return; fi
+
+  local primary
+  primary=$(jq -r --arg r "$role" '.roles[$r].primary // empty' "$POLICY" 2>/dev/null)
+  if [ -z "$primary" ]; then
+    echo "inherit"   # 未定義の role はセッションのモデルを継承する
+    return
+  fi
+
+  if ! is_disabled "$primary"; then echo "$primary"; return; fi
+
+  # primary が無効なら fallback を順に降りる
+  local fb
+  while IFS= read -r fb; do
+    [ -z "$fb" ] && continue
+    if ! is_disabled "$fb"; then echo "$fb"; return; fi
+  done < <(jq -r --arg r "$role" '.roles[$r].fallback[]?' "$POLICY" 2>/dev/null)
+
+  echo "inherit"   # 全て無効なら継承にフォールバック
+}
+
+case "${1:-}" in
+  --list)
+    printf "%-18s %-10s %s\n" "ROLE" "RESOLVED" "PRIMARY(fallback)"
+    while IFS= read -r r; do
+      p=$(jq -r --arg r "$r" '.roles[$r].primary' "$POLICY")
+      f=$(jq -r --arg r "$r" '[.roles[$r].fallback[]?]|join(",")' "$POLICY")
+      printf "%-18s %-10s %s(%s)\n" "$r" "$(resolve "$r")" "$p" "$f"
+    done < <(jq -r '.roles|keys[]' "$POLICY")
+    d=$(disabled_list | tr -s ',' ' ' | xargs)
+    [ -n "$d" ] && echo "disabled: $d"
+    ;;
+  --disable)
+    [ -z "${2:-}" ] && { echo "usage: --disable <model>"; exit 1; }
+    tmp=$(mktemp)
+    jq --arg m "$2" '.disabled = ((.disabled // []) + [$m] | unique)' "$POLICY" > "$tmp" && mv "$tmp" "$POLICY"
+    echo "disabled に追加: $2"
+    ;;
+  --enable)
+    [ -z "${2:-}" ] && { echo "usage: --enable <model>"; exit 1; }
+    tmp=$(mktemp)
+    jq --arg m "$2" '.disabled = ((.disabled // []) - [$m])' "$POLICY" > "$tmp" && mv "$tmp" "$POLICY"
+    echo "disabled から削除: $2"
+    ;;
+  "")
+    echo "usage: resolve-model.sh <role> | --list | --disable <model> | --enable <model>"
+    exit 1
+    ;;
+  *)
+    resolve "$1"
+    ;;
+esac

--- a/scripts/resolve-model.sh
+++ b/scripts/resolve-model.sh
@@ -76,6 +76,7 @@ case "${1:-}" in
     done < <(jq -r '.roles|keys[]' "$POLICY")
     d=$(disabled_list | tr -s ',' ' ' | xargs)
     [ -n "$d" ] && echo "disabled: $d"
+    exit 0
     ;;
   --disable)
     [ -z "${2:-}" ] && { echo "usage: --disable <model>"; exit 1; }


### PR DESCRIPTION
## 概要

plan / 抽象レビューは **fable**、実装は **opus**、機械的作業は **haiku** という使い分けを可能にし、**fable の利用枠上限時はフォールバック**する。

## ★ 割当の軸は call-site（呼び出し箇所）

Issue のラベルや層ではなく、**呼び出し箇所の役割**で決める。

**1つの issue の中に抽象（仕様レビュー）と具体（実装）が混在する**ため、issue 単位の割当では粒度が粗すぎる。当初案の「ラベル → role → model」はこの点で誤りだった。

## 追加したもの

| ファイル | 役割 |
|---|---|
| `.claude/model-policy.json` | **role → モデルの単一情報源** |
| `scripts/resolve-model.sh` | role からモデル名を解決 |
| `.claude/rules/model-policy.md` | call-site と role の対応表 |

| role | 既定 | fallback |
|---|---|---|
| `planning` / `abstract-review` | fable | opus → sonnet |
| `implementation` / `verification` | opus | sonnet |
| `mechanical` | haiku | sonnet |

## 枠上限への対応

```bash
bash scripts/resolve-model.sh --disable fable   # 枠を使い切ったとき
bash scripts/resolve-model.sh --enable  fable   # 復帰
bash scripts/resolve-model.sh --list            # 現在の解決結果

MODEL_POLICY_DISABLE=fable,opus /task-run #101  # 一時的な切り替え
```

**多段フォールバック**（fable → opus → sonnet → inherit）に対応。

## エージェント定義に frontmatter を追加

`.claude/agents/*.md` の3ファイルには **frontmatter が無く、`model` を書く場所自体が存在しなかった**（#78 で PushVoice の agents 9個も同様と確認済み）。

| エージェント | role |
|---|---|
| `auto-reviewer` | `abstract-review` |
| `issue-scanner` | `mechanical` |
| `issue-diff-analyzer` | `verification` |

`model:` は `inherit` のままにし、実際の割当はポリシー側で決める（**モデル名を2箇所に書かない**）。

## 検証

- 通常時 / fable 無効時 / fable+opus 無効時の**3状態**で解決結果を確認
- 多段フォールバックが期待どおり動作
- `--enable` での復帰を確認
- 全サブコマンドの終了コードを確認（`--list` が disabled 空のとき非ゼロを返すバグを発見・修正）
- quality-check.sh exit 0

## 注意

メインのモデルを切り替えても、**role が割り当てられた call-site は追従しません**。planning を fable にしても、実装は `implementation` role により opus のままです。これが本Issueの目的です。

Closes #71