### PR TITLE
fix #108: sync/contribute/install の検証残不具合＋新規インストール不能バグを修正

### DIFF
--- a/.claude/skills/template-sync/SKILL.md
+++ b/.claude/skills/template-sync/SKILL.md
@@ -156,7 +156,7 @@ fi
 **移行は行わない。** 対話で確認できないため、固有記述を失う危険がある。
 
 代わりに `user-action` ラベルつきの issue を **`/issue-create` 経由で**起票し、処理を止めずに次へ進む
-（`gh issue create` を直接呼ばない。`.claude/rules/template/skills.md` の単一情報源の原則）。
+（`gh` コマンドで直接作成しない。`.claude/rules/template/skills.md` の単一情報源の原則）。
 
 1. 以下の本文を一時ファイル（例: `$TMP_DIR/migration-issue.md`）に書き出す:
 

--- a/.claude/skills/template-sync/SKILL.md
+++ b/.claude/skills/template-sync/SKILL.md
@@ -21,8 +21,8 @@ description: Sync updates from research-project-template (テンプレート更�
 | `.claude/rules/*.md`（直下） | **触らない**。例外: 旧構造からの移行時（`template/` 不在）のみ、テンプレートと同名ファイルは移行処理される |
 | `.claude/skills/` | 差分表示→選択適用 |
 | `.claude/agents/` | 差分表示→選択適用 |
-| `.claude/commands/` | 差分表示→選択適用 |
 | `.claude/worktree-config.json` | 差分表示→選択適用 |
+| `.claude/model-policy.json` | 差分表示→選択適用 |
 | `.devcontainer/` | 差分表示→選択適用 |
 | `scripts/` | 差分表示→選択適用 |
 | `.spec/*.md` の**既定節** | **マーカー間を自動差し替え**（`scripts/sync-spec-defaults.sh`。**プロジェクト固有節は触らない**） |
@@ -155,27 +155,39 @@ fi
 
 **移行は行わない。** 対話で確認できないため、固有記述を失う危険がある。
 
-代わりに `user-action` ラベルつきの issue を起票し、処理を止めずに次へ進む。
+代わりに `user-action` ラベルつきの issue を **`/issue-create` 経由で**起票し、処理を止めずに次へ進む
+（`gh issue create` を直接呼ばない。`.claude/rules/template/skills.md` の単一情報源の原則）。
 
-```bash
-gh issue create \
-  --title "chore: 543行世代の CLAUDE.md を .claude/rules/template/ 構造へ移行する" \
-  --label "chore,user-action" \
-  --body "## 背景
+1. 以下の本文を一時ファイル（例: `$TMP_DIR/migration-issue.md`）に書き出す:
 
-/template-sync が旧構造（.claude/rules/ が存在しない）を検出しました。
-CLAUDE.md にワークフロールールとプロジェクト固有記述が混在しているため、
-テンプレートの更新が自動で取り込めない状態です。
+   ```markdown
+   ## 背景
 
-## 対応
+   /template-sync が旧構造（.claude/rules/ が存在しない）を検出しました。
+   CLAUDE.md にワークフロールールとプロジェクト固有記述が混在しているため、
+   テンプレートの更新が自動で取り込めない状態です。
 
-対話モードで \`/template-sync\` を実行し、重複部分の diff を確認しながら
-固有記述を切り出してください（自動移行は行いません）。
+   ## 対応
 
-## 注意
+   対話モードで `/template-sync` を実行し、重複部分の diff を確認しながら
+   固有記述を切り出してください（自動移行は行いません）。
 
-- 固有記述の自動削除は禁止。1件ずつ確認すること"
-```
+   ## 注意
+
+   - 固有記述の自動削除は禁止。1件ずつ確認すること
+   ```
+
+2. `/issue-create` で起票する。移行はどの task にも属さない単発作業のため `--parent` は付けない:
+
+   ```
+   Skill(skill="issue-create", args="--type chore --title 'chore: 543行世代の CLAUDE.md を .claude/rules/template/ 構造へ移行する' --body-file $TMP_DIR/migration-issue.md")
+   ```
+
+3. 作成された issue に状態ラベルを付与する（種類ラベル以外は `/issue-create` の対象外のため）:
+
+   ```bash
+   gh issue edit "$ISSUE_ID" --add-label user-action
+   ```
 
 Issue 番号を完了報告に記録し、sync の残りの Step は通常どおり続行する。
 
@@ -185,12 +197,12 @@ Issue 番号を完了報告に記録し、sync の残りの Step は通常どお
 `.claude/rules/` は Step 2、`.spec/*.md` は Step 3 で処理済みなので**含めない**。
 
 ```bash
-# 対象ディレクトリ（rules と .spec は処理済み）
+# 対象（rules と .spec は処理済み）。install.sh の ITEMS / contribute-detect と対称に保つ
 SYNC_TARGETS=(
     ".claude/agents"
-    ".claude/commands"
     ".claude/skills"
     ".claude/worktree-config.json"
+    ".claude/model-policy.json"
     ".devcontainer"
     "scripts"
 )
@@ -209,14 +221,14 @@ done
 ## テンプレート更新の検出結果
 
 ### 新規ファイル（テンプレートにのみ存在）
-- `.claude/commands/new-command.md`
+- `.claude/skills/new-skill/SKILL.md`
 
 ### 変更されたファイル
-- `.claude/commands/commit/merge.md` (テンプレート側で更新あり)
+- `.claude/skills/commit-merge/SKILL.md` (テンプレート側で更新あり)
 - `scripts/safe-remove-worktree.sh` (テンプレート側で更新あり)
 
 ### ローカルのみのファイル（テンプレートに存在しない）
-- `.claude/commands/custom-command.md` (ローカル追加)
+- `.claude/skills/custom-skill/SKILL.md` (ローカル追加)
 
 ### CLAUDE.md の差分（参考表示のみ）
 [diff表示]

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# ルート直下のみ（裸の lib/ は scripts/lib/ 等も無言で除外してしまう）
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/install.sh
+++ b/install.sh
@@ -161,11 +161,11 @@ git clone --depth 1 --branch "$TEMPLATE_BRANCH" "$TEMPLATE_REPO" "$TMP_DIR/templ
 
 # Files to install
 ITEMS=(
-    ".claude/commands"
     ".claude/skills"
     ".claude/agents"
     ".claude/rules"
     ".claude/worktree-config.json"
+    ".claude/model-policy.json"
     ".devcontainer"
     "scripts"
     ".spec"
@@ -188,7 +188,13 @@ for item in "${ITEMS[@]}"; do
         existed=false
         [[ -e "$dst" ]] && existed=true
         mkdir -p "$(dirname "$dst")"
-        cp -r "$src" "$dst"
+        if [[ -d "$src" ]] && [[ -d "$dst" ]]; then
+            # --force で既存ディレクトリを更新する場合は中身をマージコピーする。
+            # `cp -r "$src" "$dst"` は dst の中へネストコピーしてしまう（例: .spec/.spec/）
+            cp -r "$src/." "$dst/"
+        else
+            cp -r "$src" "$dst"
+        fi
         # .spec/issues/ はテンプレート自身の仕様アーカイブ。新規プロジェクトには持ち込まない
         # （必読3ファイルとディレクトリ構造だけを残す）。既存 .spec がある場合は触らない
         if [[ "$item" == ".spec" ]] && [[ "$existed" != true ]]; then

--- a/scripts/template-contribute-detect.sh
+++ b/scripts/template-contribute-detect.sh
@@ -9,10 +9,13 @@
 # 判別基準:
 #   **テンプレート由来パスの変更 = 還流候補。それ以外 = プロジェクト固有。**
 #
-#   テンプレート由来パス:
+#   テンプレート由来パス（install.sh の ITEMS / template-sync の対象と対称に保つ）:
 #     .claude/rules/template/       （MANIFEST.sha256 は生成物なので除外）
 #     .claude/skills/
 #     .claude/agents/
+#     .claude/worktree-config.json
+#     .claude/model-policy.json
+#     .devcontainer/
 #     scripts/
 #     .spec/*.md の**既定節のみ**（`# プロジェクト固有` 以降は還流しない）
 #     .claude/rules/template.bak-*/ （sync が退避したローカル改変＝還流候補そのもの）
@@ -195,11 +198,19 @@ scan_dir() {
 }
 
 # --- テンプレート由来ディレクトリ ---
+# install.sh の ITEMS / template-sync の SYNC_TARGETS と対称に保つこと
 # MANIFEST.sha256 は generate-rules-manifest.sh の生成物であり、還流の対象にしない
 scan_dir ".claude/rules/template" "$RULES_MANIFEST_NAME"
 scan_dir ".claude/skills"
 scan_dir ".claude/agents"
+scan_dir ".devcontainer"
 scan_dir "scripts"
+
+# --- テンプレート由来の単体ファイル ---
+for single in ".claude/worktree-config.json" ".claude/model-policy.json"; do
+  [ -f "$PROJECT_ROOT/$single" ] || continue
+  compare_file "$single" "$SOURCE_DIR/$single" "$PROJECT_ROOT/$single"
+done
 
 # --- sync が退避したローカル改変（D1-b の template.bak-*/） ---
 for bak in "$PROJECT_ROOT"/.claude/rules/template.bak-*/; do


### PR DESCRIPTION
Closes #108

## 修正内容

検証（#80 / #101）で記録した残不具合4件＋フィクスチャ検証中に発見した2件。

- **F1**: install.sh `--force` 時の `cp -r` が既存ディレクトリへネストコピーする問題をマージコピーに変更（ローカル追加ファイルは保持、テンプレート由来は上書き）
- **F2**: template-sync スキルの issue 直接作成を `/issue-create` 経由に置換（単一情報源）
- **F3**: contribute-detect の対象に `.devcontainer/`・`.claude/worktree-config.json`・`.claude/model-policy.json` を追加し、install/sync と対称化
- **F4**: `.gitignore` の `lib/` `lib64/` をルート直下にアンカー（`scripts/lib/` 等の無言除外を防止）
- **F5**: 実在しない `.claude/commands` が ITEMS に残り `set -e` で**新規インストールが必ず失敗**していた問題を修正（sync 対象・例示からも除去）
- **F6**: `.claude/model-policy.json` が配布されず新規プロジェクトで `resolve-model.sh` が参照先を失う問題を修正

## 検証

- フィクスチャ（ブランチ clone 方式）: 新規インストール成功 / `--force` 再インストールでネスト無し・ローカル保持・テンプレート上書き / contribute-detect が devcontainer と model-policy.json の改変を検出 — 全 PASS（#108 コメント参照）
- `git check-ignore`: `scripts/lib/` 非マッチ、ルート `lib/` マッチ維持
- `scripts/quality-check.sh` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)