### PR TITLE
fix(quality-gate): ファイル単位の検査を変更ファイルに限定する

### DIFF
--- a/scripts/check-skill-references.sh
+++ b/scripts/check-skill-references.sh
@@ -20,7 +20,7 @@
 #      新スキルを足したのに一覧を更新しない事故（#114 H6: 6スキルが未掲載）の再発防止
 #
 # 除外（当時の実行記録であり、書き換えると履歴が壊れる）:
-#   .spec/issues/  docs/surveys/  data/shared/integrity-reviews/
+#   .spec/issues/  docs/surveys/  data/shared/integrity-reviews/  results/
 #
 # 行単位の除外（正当に旧名を書く必要がある箇所）:
 #   - `（旧 ...）` / `(旧 ...)` … リネームの移行導線。ユーザーに旧名を示すのが目的
@@ -42,7 +42,7 @@ case "${1:-}" in
 esac
 
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-cd "$ROOT"
+cd "$ROOT" || exit 1
 
 [ -d .claude/skills ] || { echo "[skill-refs] .claude/skills が無いためスキップ"; exit 0; }
 
@@ -54,6 +54,7 @@ targets() {
     | grep -vE '^\.spec/issues/' \
     | grep -vE '^docs/surveys/' \
     | grep -vE '^data/shared/integrity-reviews/' \
+    | grep -vE '^results/' \
     | grep -E '\.(md|sh|json)$|^claude-san$|^install\.sh$|^setup\.sh$'
 }
 
@@ -78,7 +79,7 @@ while IFS= read -r name; do
   if [ -n "$hits" ]; then
     # 全角括弧が変数名の一部として解釈されるため ${} で明示的に閉じる
     echo "[skill-refs] 旧表記 '${OLD}'（正: ${name}）:"
-    echo "$hits" | sed 's/^/  /'
+    printf '%s\n' "${hits//$'\n'/$'\n'  }" | sed '1s/^/  /'
     FOUND=1
   fi
 done < <(ls .claude/skills)
@@ -94,7 +95,7 @@ for pair in "issue-auto|task-run" "issue-cycle|epic-cycle" "start-task|task-star
     "${FILES[@]}" 2>/dev/null)
   if [ -n "$hits" ]; then
     echo "[skill-refs] 旧名 '${OLD}'（正: ${new}）:"
-    echo "$hits" | sed 's/^/  /'
+    printf '%s\n' "${hits//$'\n'/$'\n'  }" | sed '1s/^/  /'
     FOUND=1
   fi
 done
@@ -139,6 +140,7 @@ else
     | sed -E 's|.*/||' | sort -u)
   if [ -n "$IGNORED" ]; then
     LISTED=$(comm -23 <(printf '%s\n' "$LISTED_RAW") <(printf '%s\n' "$IGNORED"))
+    # shellcheck disable=SC2086  # IGNORED is an intentional word list
     echo "[skill-refs] 一覧から除外（skills-ignore）: $(printf '%s ' $IGNORED)"
   else
     LISTED="$LISTED_RAW"
@@ -187,7 +189,7 @@ if [ "$FOUND" -ne 0 ]; then
   echo "             参照は実在するスキル名（ハイフン区切り）に修正してください。"
   echo "             一覧の差分は上の案内に従うこと（template/ の書き換え可否に注意）。"
   echo "             実在するスキル:"
-  ls .claude/skills | sed 's/^/  \//'
+  find .claude/skills -mindepth 1 -maxdepth 1 -type d -printf '  /%f\n' | sort
   exit 1
 fi
 

--- a/scripts/quality-check.sh
+++ b/scripts/quality-check.sh
@@ -38,10 +38,58 @@ run_check() {
   fi
 }
 
+# 変更ファイルの解決（#142 / #153）
+#   ツリー全体を検査すると、そのファイルを1行も触っていない PR が既存の指摘で落ちる。
+#   これは #105 が changed-file 判定から取り除いたのと同じ誤検出なので、
+#   ファイル単位の検査は base ref との差分に限定する。
+#   base は origin/<既定> -> ローカル<既定> の順で実在するものを採る。
+#   どちらも解決できないなら「検査が走らなかった」ことを明示して止める（PASS にしない）。
+BASE_REF=""
+CHANGED_FILES=""
+
+resolve_base_ref() {
+  local cand
+  if [ -n "${QUALITY_BASE_BRANCH:-}" ]; then
+    git rev-parse --verify --quiet "$QUALITY_BASE_BRANCH" >/dev/null && {
+      BASE_REF="$QUALITY_BASE_BRANCH"; return 0; }
+    return 1
+  fi
+  local default_branch
+  default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
+  [ -n "$default_branch" ] || default_branch=main
+  for cand in "origin/$default_branch" "$default_branch"; do
+    if git rev-parse --verify --quiet "$cand" >/dev/null; then BASE_REF="$cand"; return 0; fi
+  done
+  return 1
+}
+
+compute_changed_files() {
+  local base
+  resolve_base_ref || return 1
+  base="$(git merge-base HEAD "$BASE_REF" 2>/dev/null)" || return 1
+  CHANGED_FILES="$(git diff --name-only --diff-filter=d "$base" HEAD 2>/dev/null; git diff --name-only --diff-filter=d HEAD 2>/dev/null; git ls-files --others --exclude-standard 2>/dev/null)" || return 1
+  CHANGED_FILES="$(printf '%s\n' "$CHANGED_FILES" | sort -u)"
+  return 0
+}
+
+# changed_of <拡張子> -> 変更された該当ファイルを1行1件で返す
+changed_of() {
+  printf '%s\n' "$CHANGED_FILES" | grep -E "\\.$1\$" || true
+}
+
 echo "=== Running quality checks ==="
 
 SCOPE="${QUALITY_SCOPE:-all}"
 echo "scope: $SCOPE"
+
+if [ "$SCOPE" != "docs" ]; then
+  if compute_changed_files; then
+    echo "base: $BASE_REF（ファイル単位の検査は変更分のみ）"
+  else
+    echo "!!! FAILED: base ref を解決できず変更ファイルを特定できない（検査が走らなかったことは PASS ではない）"
+    FAILED=1
+  fi
+fi
 
 # ---------------------------------------------------------------------------
 # Python (uv + ruff + mypy + pytest)
@@ -88,11 +136,15 @@ if [ "$SCOPE" = "docs" ]; then
 elif ! command -v shellcheck >/dev/null 2>&1; then
   skip "shellcheck (未インストール)"
 else
-  mapfile -t SH_FILES < <(git ls-files '*.sh' 2>/dev/null)
+  mapfile -t SH_FILES < <(changed_of sh)
   if [ ${#SH_FILES[@]} -eq 0 ]; then
-    skip "shellcheck (対象ファイル無し)"
+    skip "shellcheck (変更された *.sh が無い vs $BASE_REF)"
   else
-    run_check "shellcheck (${#SH_FILES[@]} files)" shellcheck "${SH_FILES[@]}"
+    # -x/--source-path: sourced lib を「呼び出し元の CWD」ではなくスクリプト自身の
+    # ディレクトリから解決する。単体検査にすると SC1091 が必ず出るため必須。
+    run_check "shellcheck (${#SH_FILES[@]} changed)" \
+      shellcheck -x --source-path=SCRIPTDIR "${SH_FILES[@]}"
+    echo "    （変更された ${#SH_FILES[@]} 件のみ検査。ツリーの残りは未検査）"
   fi
 fi
 

--- a/tests/test_quality_check_scope.sh
+++ b/tests/test_quality_check_scope.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# quality-check.sh の検査範囲に関する回帰テスト（#142 / #153）
+#
+# ツリー全体を検査すると、そのファイルを1行も触っていない PR が既存の指摘で落ちる。
+# #105 が changed-file 判定から取り除いたのと同じ誤検出なので、ファイル単位の検査は
+# base ref との差分に限定する。ここではその不変条件を静的に pin する
+# （gate 自体は uv sync 等で重いので、実行せずスクリプトの構造を検査する）。
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+GATE="scripts/quality-check.sh"
+PASSED=0
+FAILED=0
+ok() { PASSED=$((PASSED + 1)); printf '  ok   %s\n' "$1"; }
+ng() { FAILED=$((FAILED + 1)); printf '  FAIL %s\n' "$1"; }
+
+echo "=== quality-check scope self-test ==="
+
+# 1) shellcheck が全件走査に戻っていないこと
+if grep -q "git ls-files '\*\.sh'" "$GATE"; then
+  ng "shellcheck が git ls-files で全件走査している（#142 の回帰）"
+else
+  ok "shellcheck は全件走査していない"
+fi
+
+# 2) 変更ファイル由来の集合を使っていること
+if grep -q 'changed_of sh' "$GATE"; then
+  ok "shellcheck は changed_of で変更ファイルに限定されている"
+else
+  ng "changed_of による限定が無い"
+fi
+
+# 3) base ref の解決とフォールバック順序があること
+# shellcheck disable=SC2016  # these are grep patterns; $ must stay literal
+if grep -q 'resolve_base_ref' "$GATE" && grep -q 'origin/\$default_branch' "$GATE"; then
+  ok "base ref を origin -> ローカルの順で解決する"
+else
+  ng "base ref の解決処理が見当たらない"
+fi
+
+# 4) 「検査が走らなかった」を PASS に畳まないこと
+if grep -q 'base ref を解決できず' "$GATE" && \
+   awk '/base ref を解決できず/{found=1} found && /FAILED=1/{ok=1} END{exit !ok}' "$GATE"; then
+  ok "base ref 解決不能を FAILED にする（PASS に畳まない）"
+else
+  ng "base ref 解決不能が握り潰されている"
+fi
+
+# 5) sourced lib を追う設定（単体検査では SC1091 が必ず出るため必須）
+if grep -q -- '--source-path=SCRIPTDIR' "$GATE"; then
+  ok "shellcheck -x --source-path=SCRIPTDIR を使っている"
+else
+  ng "sourced lib の解決設定が無い（SC1091 で落ちる）"
+fi
+
+echo
+echo "$PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## 元 issue

- `omron-sinicx/delta-clip-dev#153` fix: template-sync で quality-check.sh の #142 修正（shellcheck の変更ファイル限定）が失われた
- 元の修正: 同 `#142`（PR #143）

## 動機

`quality-check.sh` の shellcheck が `git ls-files '*.sh'` で**ツリー全件を走査する**ため、**シェルを1行も触っていない PR が既存の指摘で FAIL** します。

下流プロジェクトの実測（31ファイル）:

| スクリプト | 指摘数 |
|---|---|
| `setup_8gpu_ollama.sh` | 17 |
| `init-data.sh` | 4 |
| `safe-remove-worktree.sh` | 3 |
| `setup-worktree.sh` | 2 |
| **`resolve-model.sh`（テンプレート同梱）** | **2** |
| ほか3ファイル | 各1 |
| **合計** | **32** |

この状態では Python だけを変更した PR も通りません。`check_format`（black 相当）は変更ファイル限定なのに shellcheck だけが全件、という**同一スクリプト内の非対称**でもあります。

これは changed-file 判定から取り除いたのと同じ誤検出で、「PR で触っていないファイルを検査対象に含めない」という既存の原則に反します。

### 補足: 一度直したものが消えた経緯

下流プロジェクトは同じ修正を `#142` で入れていましたが、**還流していなかった**ため `/template-sync` でテンプレート版に上書きされ、消失しました。`scripts/` は `.claude/rules/template/` と違い MANIFEST による改変検出の対象外なので、退避もされず黙って消えます。今回はその再発防止も兼ねて還流します。

## 汎用性の根拠

- **既存スクリプトに shellcheck 指摘が1件でもあるプロジェクトで必ず起きます。** テンプレート同梱の `resolve-model.sh` 自体に SC2015 が2件あるため、**新規プロジェクトでも初日から発生します**
- 修正は base ref との差分を取るだけで、ドメインにも言語構成にも依存しません
- `check_format` が既に変更ファイル限定なので、**非対称を解消して既存設計に揃える**変更です

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `scripts/quality-check.sh` | `resolve_base_ref` / `compute_changed_files` / `changed_of` を追加、shellcheck を変更ファイル限定に、`-x --source-path=SCRIPTDIR`、base 解決不能は `FAILED` |
| `scripts/check-skill-references.sh` | `results/` を除外に追加（実行記録は書き換えない。`.spec/issues/` と同じ趣旨）+ 自身の shellcheck 指摘4件（SC2164/SC2001×2/SC2012/SC2086）を修正 |
| `tests/test_quality_check_scope.sh` | **新規**。不変条件を静的に pin する回帰テスト5件 |

### 設計上のポイント

- **base ref は `origin/HEAD` から既定ブランチを取得**します（`main` 決め打ちにしない）。`origin/<既定>` → ローカル`<既定>` の順にフォールバックし、`QUALITY_BASE_BRANCH` で明示指定もできます
- **`-x --source-path=SCRIPTDIR` は必須です。** 全件走査時は `quality-base.sh` 等も入力に含まれるため SC1091 が出ませんが、変更ファイル単体にした瞬間に発火します。この修正の必要条件です
- **base ref を解決できない場合は `FAILED=1`** にします。「検査が走らなかったこと」を PASS に畳みません
- テストは gate 本体を実行しません（`uv sync` が走り重いため）。代わりに `git ls-files '*.sh'` の復活を含む5つの不変条件を静的に検査します

## 品質チェック

- ✅ **汚染チェック**: プロジェクト固有語の混入なし
- ✅ **テンプレート上で動作確認**: `bash tests/test_quality_check_scope.sh` → **5 passed, 0 failed**
- ✅ 変更した3ファイルすべて shellcheck clean（意図的な SC2016/SC2086 は理由付きで明示抑制）
- ✅ 構文チェック（`bash -n`）通過

---
*This PR was created via `/template-contribute`.*
