### PR TITLE
fix #133: data/shared の symlink ガードと追跡ポリシーの修正（PR #84 の還流）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,16 @@
 worktrees/
 
 # データディレクトリ（共有データは追跡しない）
-data/shared/**
-!data/shared/.gitkeep
+# data/shared 自体を追跡しないこと（.gitkeep も置かない）。
+# 追跡すると `git worktree add` が実ディレクトリを具現化し、
+# 共有データへの symlink を張れなくなる（張ると git が恒久的に汚れる）。
+# メインリポジトリ側の data/shared は scripts/init-data.sh が作る。
+#
+# ★ `data/shared/**` ではなく `data/shared` と書くこと。
+#   `/**` は配下にしかマッチせずパス自体にマッチしないため、worktree で symlink 化した
+#   data/shared が未追跡として露出し、`git add .` でホストの絶対パスを含む symlink が
+#   コミットされてしまう。`data/shared` なら symlink 自体も配下も両方無視される。
+data/shared
 data/local/
 
 # Python

--- a/.spec/issues/133-auto-decisions.md
+++ b/.spec/issues/133-auto-decisions.md
@@ -1,0 +1,94 @@
+# Issue #133 自動判断ログ
+
+## メタ情報
+- 判断日時: 2026-08-02 16:05
+- 自動処理: /task-run（親 task #132）
+- 対象仕様: .spec/issues/133-shared-symlink-guard.md（D1〜D3）
+- 出自: PR #84（`git diff main pr84 -- scripts/setup-worktree.sh` で原案確認済み）
+- 注記: `.spec/` 3ファイルは既定節あり・**プロジェクト固有節は未記入**。既定のみで判断した
+  （プロジェクト固有の失敗パターンは捕捉できていない自覚を残す）
+
+## 事前検証（実測した事実）
+
+| # | 事実 | 確認方法 |
+|---|------|---------|
+| F1 | `data/shared/.gitkeep` は **git 追跡ファイル**。fresh worktree では checkout により `data/shared` が必ず「.gitkeep 入りの実ディレクトリ」として具現化する。**つまり D1 の V2 経路（空ディレクトリ置換）は例外ケースではなく全新規 worktree の標準経路** | `git ls-files data` |
+| F2 | `.gitignore` は `data/shared/**` + `!data/shared/.gitkeep`。パス `data/shared` **自体は ignore されない** | `git check-ignore data/shared` → exit 1 |
+| F3 | D1 の空ディレクトリ置換を実行すると git status が ` D data/shared/.gitkeep` + `?? data/shared` で**恒久的に汚れる**（sandbox で再現） | scratchpad で git init して再現 |
+| F4 | `data/shared` が**実ファイル**の場合、現仕様の表に該当行が無く `ln -sfn` に落ち、**ファイルは黙って削除される**（sandbox で再現。「precious」入りファイルが無警告で消えた） | scratchpad で `ln -sfn` を実行 |
+| F5 | `setup-worktree.sh` の呼び出し元は `.claude/skills/worktree-setup/setup.sh`（`exec` の薄いラッパ）**のみ**。`install.sh` / `/worktree-init`（init.sh → init-data.sh）/ `/issue-start` からは呼ばれていない | 全 skills / scripts / install.sh を grep |
+| F6 | PR #84 原案には退行が含まれる: 実行ビット 100755→100644、`read -r` の `-r` 削除（shellcheck SC2162）、`/worktree-safe-remove`→`/worktree/safe-remove`（旧スキル表記） | `git diff main pr84` |
+
+## 判断一覧
+
+### 1. D1: 実ディレクトリの検出と分岐
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | 実ディレクトリ検出の分岐（空→置換 / データあり→exit 1 / 読めない→停止）を導入してよいか。データ喪失経路を塞げているか。exit 1 が初期化フローを壊さないか |
+| 判断 | ⚠️ **警告付き許可（下記条件 C1・C2 の仕様反映を必須とする）** |
+| 理由 | 方向は正しい。現状の `ln -sf` は R-D01 / KI-D03 型の silent-wrong そのもので、INV-D03（重要データは data/shared に置く＝worktree 削除で消えない）の保証を実質無効化している。「データありなら自動移動せず停止して案内」は握り潰し回避の正しい設計。exit 1 の影響も F5 のとおり呼び出し元は単独スキルのみで、初期化フロー（install / worktree-init）には組み込まれておらず、**停止しても壊れる自動フローは存在しない**。ただし仕様の表には2つの具体的な穴がある（下記） |
+| 参照 | R-D01、KI-D03、INV-D03、F1〜F5、`.claude/rules/template/data-protection.md` |
+| 自信度（参考記録） | 80% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+**条件 C1（データ喪失経路の残り）**: `data/shared` が**実ファイル**（symlink でもディレクトリでもないが存在する）の場合、D1 の表に該当行が無く `ln -sfn` に落ちて**ファイルが黙って消える**（F4 で実証）。表に「**存在するが symlink でもディレクトリでもない → 停止**」の行を追加すること。壊れた symlink は `-L` が真なので既存の symlink 分岐に入り、削除されるのはリンクのみ（データ喪失なし）→ 追加対応不要。data/shared が別ターゲットを指す symlink も同分岐で非対話時は exit 0 温存（V5 の既存挙動）→ データ喪失なし。
+
+**条件 C2（標準経路で git が恒久的に汚れる）**: F1 のとおり V2 経路は**全新規 worktree で必ず発火**し、F3 のとおり実行後は ` D data/shared/.gitkeep` + `?? data/shared` で git が恒久的に汚れる。エージェントが `.gitkeep` の削除をコミットして main に伝播する退行リスクがあり、親 task goal「退行なく反映」に反する。仕様に .gitignore / 追跡の扱い（例: `.gitignore` を `data/shared`（エントリ自体）に変更し `git rm --cached data/shared/.gitkeep`、物理ファイルは main リポジトリに残す）を明記し、検証項目「**V2 実行後に git status が汚れないこと**」を追加すること。※現行の壊れた挙動（dir 内にリンク生成）は偶然 git-clean だったため、これは新規に顕在化する差分である。
+
+### 2. D2: 旧バージョンが作った stray link の片付け
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | `data/shared` 内の stray symlink を自動削除してよいか。ユーザーが意図的に作った symlink を誤って消さないか |
+| 判断 | ✅ **許可（仕様の文言修正を推奨）** |
+| 理由 | (1) 削除対象は **readlink が SHARED_DATA_PATH に厳密一致する symlink のみ**（PR 原案の条件）で、リンク自体を消すだけで**参照先データは消えない**ため、誤検出してもデータ喪失は起きない。(2) data/shared 自体が SHARED_DATA_PATH への symlink になった後、その中に同じ場所を指すリンクは自己参照であり保持価値が無い。(3) パス正規化ずれ（末尾スラッシュ等）で一致しない場合は「データあり」として**停止側に倒れる**ため安全。(4) 空判定より前に実行する順序も正しい。文言修正: 仕様は「`shared` という symlink」とするが、旧バグが作る名前は **`basename $SHARED_DATA_PATH`** であり `shared` 固定ではない。「readlink が SHARED_DATA_PATH に一致する symlink」に修正すること（名前固定だと救済漏れが出る） |
+| 参照 | PR #84 原案の stray 判定条件、KI-D03（安全側は停止） |
+| 自信度（参考記録） | 90% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+### 3. D3: メッセージの多言語化
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | `msg()` に ja / zh / en の新キーを追加してよいか |
+| 判断 | ✅ **許可** |
+| 理由 | 既存の作法（msg 関数 + case 分岐）に一致。既存パターン優先の原則どおり。**ただし PR #84 原案の混入退行を取り込まないこと**（F6: 実行ビット 100644 化、`read -r` の `-r` 削除、`/worktree/safe-remove` 旧表記）。仕様が「symlink ガード部分のみ抽出」としているのは正しく、V6 がこれを捕捉する |
+| 参照 | F6、scripts/setup-worktree.sh 既存の msg() 実装 |
+| 自信度（参考記録） | 95% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+### 4. INV-D03 との関係
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | この変更は INV-D03 の遵守側か、抵触するか |
+| 判断 | ✅ **遵守側（むしろ INV-D03 の実効化）** |
+| 理由 | INV-D03 は「重要データは data/shared に置けば worktree 削除でも消えない」という保証。現行バグはこの保証を**黙って**無効化していた（リンクが dir 内に作られ、data/shared への保存物が worktree ローカルに残り削除で消える）。D1〜D2 はこの保証を回復する変更であり、設計判断の変更ではない |
+| 参照 | INV-D03、`.claude/rules/template/data-protection.md` |
+| 自信度（参考記録） | 95% |
+| 停止条件チェック | 該当なし |
+
+### 5. V1〜V7 の十分性
+
+| 項目 | 内容 |
+|------|------|
+| 判断 | ⚠️ **不足あり。以下を追加すること** |
+| 追加 V8 | `data/shared` が**実ファイル**の場合 → 停止し、ファイルが削除されないこと（C1 対応） |
+| 追加 V9 | V2（空ディレクトリ置換）実行後に **git status が汚れない**こと（C2 対応。` D data/shared/.gitkeep` / `?? data/shared` が出ない） |
+| V4 修正 | stray 判定は名前 `shared` 固定でなく「readlink が SHARED_DATA_PATH に一致」で検証（SHARED_DATA_PATH の basename が `shared` 以外のケースを含める） |
+| V2 補強 | find の除外リストと削除リストの**一致**を確認（PR 原案は find 側で `._*` を除外するが rm 側に無く、`._foo` のみ残存時に rmdir が失敗して「削除できない」という誤解を招くメッセージで止まる。停止側なのでデータ喪失は無いが、両リストは単一情報源にすること） |
+
+## 停止判断
+
+該当なし。S1: `.spec/` 3ファイルとも存在し既定節あり（プロジェクト固有節は未記入＝記録のみ）。S2: 親 task #132 の goal は確定済み。S3: invariants / ADR への抵触なし（INV-D03 の遵守側）。S4: 検証チェックリストあり・全項目 PASS/FAIL 判定可能（不足分は追加指示で解消可能）。S5: 既存パターン（msg 作法、error/exit 作法）に沿う。S6: experiment ではない（negative 結論の扱いなし）。
+
+## goal 書き換えチェック
+
+なし。仕様は親 task #132「滞留還流の退行なき反映・symlink バグ解消」の範囲内。goal の範囲・成功条件の変更を含まない。むしろ C2 は goal の「退行なく」を守るための条件である。
+
+## 要確認フラグ（停止には至らないが不確実性が残る項目）
+
+- [ ] C2 の解法選択（.gitignore 変更 + `git rm --cached`）は main リポジトリの追跡構造を変える。実装 issue で diff を明示し、`/issue-finish` レビューで確認すること
+- [ ] 非対話モードで data/shared が別ターゲット指す symlink の場合の exit 0（「cancelled」）は既存挙動として温存（V5）。silent 気味だが本 issue のスコープ外。気になるなら別 issue
+- [ ] プロジェクト固有の `.spec/` 節が未記入のため、既定ルールのみで判断している

--- a/.spec/issues/133-shared-symlink-guard.md
+++ b/.spec/issues/133-shared-symlink-guard.md
@@ -1,0 +1,117 @@
+# Issue #133 仕様: data/shared の symlink ガード
+
+- 状態: approved（auto-reviewer 判断済み。C1/C2 と V8/V9 を反映。ログ: 133-auto-decisions.md）
+- 出自: PR #84（downstream 由来）。symlink ガード部分のみ抽出
+
+## 問題
+
+`scripts/setup-worktree.sh` は `data/shared` が **symlink かどうか**（`-L`）しか見ていない。
+
+```bash
+if [[ -L "data/shared" ]]; then   # ← symlink のときだけ処理
+    ...
+fi
+...
+ln -sf "$SHARED_DATA_PATH" data/shared
+```
+
+`data/shared` が**実ディレクトリ**の場合、`ln -sf TARGET data/shared` は
+リンクを**そのディレクトリの中**に作る（`data/shared/shared`）。
+
+結果:
+
+- worktree で `data/shared/` に保存した重要データが本体と共有されない
+- **worktree 削除でそのデータが失われる**（`.gitignore` で追跡外のため git にも残らない）
+- しかも `ln -sf` は成功し、成功メッセージまで出る → **silent-wrong**（R-D01 / KI-D03 型）
+
+これは `.claude/rules/template/data-protection.md` が保証すると謳っている
+「worktree 削除時もデータを保護する」機構そのものの不成立。**INV-D03 に関わる。**
+
+## 設計
+
+### D1: 実ディレクトリの検出と分岐
+
+`-L` の判定の後に、**symlink でない実ディレクトリ**の分岐を追加する。
+
+| 状態 | 動作 |
+|---|---|
+| symlink（壊れたものを含む） | 従来どおり（再作成の確認）。`-L` が真なのでデータ喪失は起きない |
+| **実ディレクトリ・中身が空** | 削除して symlink に置き換える（情報表示） |
+| **実ディレクトリ・データあり** | **リンクを作らず停止**し、移動コマンドを提示する |
+| **実ファイル（C1）** | **停止**。現行は分岐が無く `ln -sf` に落ちて**ファイルが無警告で消える**（実測） |
+| **読み取れない** | 停止して権限確認を促す |
+| 何も無い | 従来どおり symlink を作る |
+
+**★ C1（auto-reviewer が実測）**: 「存在するが symlink でもディレクトリでもない」行が
+仕様から抜けていた。この経路が最もデータを失う（ファイルが黙って消える）。
+
+**データがある場合に自動で移動しない。** 移動先に同名ファイルがあると壊れるため、
+判断と実行はユーザーに委ねる（案内は必ず出す＝黙って進めない）。
+
+### D1': 追跡ポリシーの修正（★ C2。これが根本原因）
+
+**空ディレクトリの置換は例外ではなく、全新規 worktree の標準経路である。**
+
+`.gitignore` が `data/shared/**` ＋ `!data/shared/.gitkeep` としているため
+**`.gitkeep` が git 追跡下にあり**、`git worktree add` は必ず `data/shared/` を
+実ディレクトリとして具現化する。つまり:
+
+- symlink を張るには毎回このディレクトリを消すことになる
+- 消すと ` D data/shared/.gitkeep` ＋ `?? data/shared` で **git が恒久的に汚れる**
+- エージェントが削除をコミットして main に伝播する退行リスクがある
+
+**追跡ポリシー自体を直す**（PR #84 の判断を採用）:
+
+```
+# 変更前
+data/shared/**
+!data/shared/.gitkeep
+
+# 変更後
+data/shared
+```
+
+- `.gitkeep` は**追跡から外す**（`git rm --cached`）。メインリポジトリ側の
+  `data/shared` は `scripts/init-data.sh` が作るので、雛形として追跡する必要が無い
+- **`data/shared/**` ではなく `data/shared` と書く。** `/**` は配下にしかマッチせず
+  **パス自体にマッチしない**ため、symlink 化した `data/shared` が未追跡として露出し、
+  `git add .` で**ホストの絶対パスを含む symlink がコミットされる**（PR #84 の指摘）
+- `scripts/ensure-gitignore.sh` の `REQUIRED_ENTRIES`（#122 で導入した単一情報源）も
+  同時に更新する。**片方だけ直すと install / sync が古いエントリを復活させる**
+
+### D2: 旧バージョンが作った stray link の片付け
+
+すでに壊れた状態のプロジェクトを救済する。`data/shared` が実ディレクトリで、
+その中に **`readlink` が `SHARED_DATA_PATH` に一致する symlink** があれば、
+旧バージョンの生成物なので削除する。削除したことは表示する。
+
+**名前で判定しない。** 旧バグが作る名前は `shared` 固定ではなく
+`basename "$SHARED_DATA_PATH"` である（auto-reviewer 指摘）。
+
+これは D1 の「中身が空か」の判定より**前**に行う（stray link を消せば空になるケースがある）。
+
+### D3: メッセージの多言語化
+
+既存の `msg()` に ja / zh / en の3言語でキーを追加する（既存の作法に合わせる）。
+
+## Fallback ホワイトリスト
+
+なし。**データがある場合は停止する**（握り潰さない）。
+
+## 検証チェックリスト
+
+- [ ] V1: `data/shared` が無い状態 → 従来どおり symlink が作られる
+- [ ] V2: `data/shared` が**空の実ディレクトリ** → 削除され symlink に置き換わる
+- [ ] V3: `data/shared` が**データ入りの実ディレクトリ** → **symlink を作らず exit 1**、
+      移動コマンドが表示される。**`data/shared/shared` が作られていないこと**を確認
+- [ ] V4: 旧バージョンの `data/shared/shared`（stray link）が検出・削除される
+- [ ] V5: 既存の symlink がある場合の挙動（再作成の確認）が変わっていない
+- [ ] V6: **退行なし** — 旧スキル表記が 0（#117）、`setup-worktree.sh` の実行ビットが 100755（#122 N）
+- [ ] V7: shellcheck 0 件、quality-check PASS
+- [ ] V8: **C1** — `data/shared` が実ファイルのとき、停止し**ファイルが消えていない**
+- [ ] V9: **C2** — 新規 worktree で setup を実行した後、`git status` が汚れない
+      （` D data/shared/.gitkeep` や `?? data/shared` が出ない）
+- [ ] V10: `.gitignore` と `ensure-gitignore.sh` の両方が更新され、
+      install / sync が古いエントリを復活させない
+- [ ] V11: **#108 F4 の退行なし** — `/lib/` のルート限定アンカーが保たれている
+      （PR #84 はここを裸の `lib/` に戻しているので取り込まない）

--- a/scripts/ensure-gitignore.sh
+++ b/scripts/ensure-gitignore.sh
@@ -33,8 +33,9 @@ set -uo pipefail
 REQUIRED_ENTRIES=(
   # worktrees/ はドット無し（.claude/rules/template/issue-hierarchy.md の規約に一致させる）
   "worktrees/"
-  "data/shared/**"
-  "!data/shared/.gitkeep"
+  # data/shared 自体を無視する（`/**` だと symlink 化したパス自体が露出し、
+  # `git add .` でホスト絶対パスを含む symlink がコミットされる）。#133
+  "data/shared"
   "data/local/"
   # /template-sync が退避したローカル改変（還流候補。コミットはしない）
   ".claude/rules/template.bak-*/"

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -40,6 +40,8 @@ msg() {
                 "stray_link_removed") echo "旧バージョンが作った不要なリンクを削除しました" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep が git 追跡下にあります。メインリポジトリで次を実行して移行してください:" ;;
                 "is_shared_store") echo "data/shared は共有データストアそのものです。ここでリンクを張ると共有データを失います" ;;
+                "gitkeep_worktree_note") echo "移行後、この worktree で git merge が .gitkeep で止まります。次も実行してください:" ;;
+                "mv_n_note") echo "（-n は同名を上書きしません / 2行目は隠しファイル）" ;;
                 "move_conflict_note") echo "同名ファイルがある場合は -n により移動されません。残ったものは中身を確認してから手動で統合してください。" ;;
                 "dir_has_data") echo "data/shared がシンボリックリンクではなく実体のあるディレクトリで、中にデータがあります" ;;
                 "move_data_first") echo "そのままではリンクできません。次のコマンドで中身をメインリポジトリへ移してから再実行してください:" ;;
@@ -76,6 +78,8 @@ msg() {
                 "stray_link_removed") echo "已删除旧版本创建的多余链接" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep 仍被 git 跟踪。请在主仓库中执行以下命令完成迁移:" ;;
                 "is_shared_store") echo "data/shared 就是共享数据存储本身。在此创建链接会丢失共享数据" ;;
+                "gitkeep_worktree_note") echo "迁移后该 worktree 的 git merge 会因 .gitkeep 失败。请同时执行:" ;;
+                "mv_n_note") echo "（-n 不覆盖同名文件 / 第二行为隐藏文件）" ;;
                 "move_conflict_note") echo "如有同名文件，-n 会跳过移动。请检查剩余文件后手动合并。" ;;
                 "dir_has_data") echo "data/shared 是真实目录（非符号链接）且其中包含数据" ;;
                 "move_data_first") echo "当前状态无法创建链接。请用以下命令将内容移动到主仓库后重新执行:" ;;
@@ -112,6 +116,8 @@ msg() {
                 "stray_link_removed") echo "Removed a stray link created by an older version" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep is still tracked by git. Run these in the main repository to migrate:" ;;
                 "is_shared_store") echo "data/shared IS the shared data store. Linking here would destroy the shared data" ;;
+                "gitkeep_worktree_note") echo "After migrating, git merge in this worktree will fail on .gitkeep. Also run:" ;;
+                "mv_n_note") echo "(-n does not overwrite; the second line moves hidden files)" ;;
                 "move_conflict_note") echo "Files with the same name are skipped by -n. Inspect what remains and merge manually." ;;
                 "dir_has_data") echo "data/shared is a real directory (not a symlink) and contains data" ;;
                 "move_data_first") echo "Cannot link as-is. Move its contents to the main repository and re-run:" ;;
@@ -242,9 +248,23 @@ mkdir -p data
 #   ここを消すと共有データを削除して自己参照 symlink を張り、
 #   以後 "Too many levels of symbolic links" で復旧不能になる。
 #   これは本 issue が塞ごうとしている silent-wrong と同型なので、最優先で止める
-if [ -d "data/shared" ] && [ ! -L "data/shared" ]; then
-    _here=$(cd data/shared 2>/dev/null && pwd -P || echo "")
-    _store=$(cd "$SHARED_DATA_PATH" 2>/dev/null && pwd -P || echo "")
+# ★ F-6: `-d` で門番してはいけない。.gitkeep を追跡から外した結果、
+#   **clone 直後は data/shared が存在しないのが既定**になった。
+#   存在しない場合も自己参照 symlink を張れてしまうので、パス比較は
+#   「実在するか」に関係なく行う（親ディレクトリまで解決して比較する）
+_resolve_path() {
+    local q="${1%/}"; [ -n "$q" ] || q="/"
+    if [ -d "$q" ]; then
+        (cd "$q" && pwd -P)
+    else
+        local d; d=$(cd "$(dirname "$q")" 2>/dev/null && pwd -P) || return 1
+        printf '%s\n' "${d%/}/$(basename "$q")"
+    fi
+}
+
+if [ ! -L "data/shared" ]; then
+    _here=$(_resolve_path "$(pwd -P)/data/shared" || echo "")
+    _store=$(_resolve_path "$SHARED_DATA_PATH" || echo "")
     if [ -n "$_here" ] && [ "$_here" = "$_store" ]; then
         echo -e "${RED}[ERROR]${NC} $(msg is_shared_store)" >&2
         echo "  data/shared = $_here" >&2
@@ -294,8 +314,9 @@ if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
         echo "" >&2
         echo "  $(msg move_data_first)" >&2
         echo "    mkdir -p \"$SHARED_DATA_PATH\"" >&2
-        echo "    mv -n data/shared/* \"$SHARED_DATA_PATH\"/   # -n: 同名を上書きしない" >&2
-        echo "    mv -n data/shared/.[!.]* \"$SHARED_DATA_PATH\"/ 2>/dev/null || true  # 隠しファイル" >&2
+        echo "    mv -n data/shared/* \"$SHARED_DATA_PATH\"/" >&2
+        echo "    mv -n data/shared/.[!.]* \"$SHARED_DATA_PATH\"/ 2>/dev/null || true" >&2
+        echo "    $(msg mv_n_note)" >&2
         echo "    rmdir data/shared" >&2
         echo "" >&2
         echo "  $(msg move_conflict_note)" >&2
@@ -309,6 +330,8 @@ if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
         warn "$(msg gitkeep_tracked)"
         echo "    cd \"$MAIN_REPO\" && git rm --cached data/shared/.gitkeep" >&2
         echo "    bash scripts/ensure-gitignore.sh" >&2
+        echo "  $(msg gitkeep_worktree_note)" >&2
+        echo "    git rm --cached data/shared/.gitkeep   # この worktree でも実行する" >&2
     fi
 
     if ! rm -rf data/shared; then

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -37,6 +37,14 @@ msg() {
                 "run_init_first") echo "先にメインリポジトリで初期化を実行してください" ;;
                 "config") echo "設定" ;;
                 "symlink_exists") echo "data/shared シンボリックリンクは既に存在します" ;;
+                "stray_link_removed") echo "旧バージョンが作った不要なリンクを削除しました" ;;
+                "gitkeep_tracked") echo "data/shared/.gitkeep が git 追跡下にあります。メインリポジトリで次を実行して移行してください:" ;;
+                "dir_has_data") echo "data/shared がシンボリックリンクではなく実体のあるディレクトリで、中にデータがあります" ;;
+                "move_data_first") echo "そのままではリンクできません。次のコマンドで中身をメインリポジトリへ移してから再実行してください:" ;;
+                "dir_replaced") echo "空の data/shared ディレクトリを削除しました（シンボリックリンクに置き換えます）" ;;
+                "dir_remove_failed") echo "data/shared ディレクトリを削除できませんでした" ;;
+                "dir_unreadable") echo "data/shared を読み取れません（権限を確認してください）" ;;
+                "not_dir_or_link") echo "data/shared がファイルとして存在します。リンクを張ると失われるため停止します" ;;
                 "recreate") echo "再作成しますか？ [y/N]" ;;
                 "cancelled") echo "キャンセルしました" ;;
                 "local_exists") echo "data/local ディレクトリは既に存在します" ;;
@@ -63,6 +71,14 @@ msg() {
                 "run_init_first") echo "请先在主仓库中运行初始化" ;;
                 "config") echo "配置" ;;
                 "symlink_exists") echo "data/shared 符号链接已存在" ;;
+                "stray_link_removed") echo "已删除旧版本创建的多余链接" ;;
+                "gitkeep_tracked") echo "data/shared/.gitkeep 仍被 git 跟踪。请在主仓库中执行以下命令完成迁移:" ;;
+                "dir_has_data") echo "data/shared 是真实目录（非符号链接）且其中包含数据" ;;
+                "move_data_first") echo "当前状态无法创建链接。请用以下命令将内容移动到主仓库后重新执行:" ;;
+                "dir_replaced") echo "已删除空的 data/shared 目录（将替换为符号链接）" ;;
+                "dir_remove_failed") echo "无法删除 data/shared 目录" ;;
+                "dir_unreadable") echo "无法读取 data/shared（请检查权限）" ;;
+                "not_dir_or_link") echo "data/shared 是一个文件。创建链接会丢失它，因此停止" ;;
                 "recreate") echo "是否重新创建？ [y/N]" ;;
                 "cancelled") echo "已取消" ;;
                 "local_exists") echo "data/local 目录已存在" ;;
@@ -89,6 +105,14 @@ msg() {
                 "run_init_first") echo "Run initialization in main repository first" ;;
                 "config") echo "Configuration" ;;
                 "symlink_exists") echo "data/shared symlink already exists" ;;
+                "stray_link_removed") echo "Removed a stray link created by an older version" ;;
+                "gitkeep_tracked") echo "data/shared/.gitkeep is still tracked by git. Run these in the main repository to migrate:" ;;
+                "dir_has_data") echo "data/shared is a real directory (not a symlink) and contains data" ;;
+                "move_data_first") echo "Cannot link as-is. Move its contents to the main repository and re-run:" ;;
+                "dir_replaced") echo "Removed the empty data/shared directory (replacing it with a symlink)" ;;
+                "dir_remove_failed") echo "Failed to remove the data/shared directory" ;;
+                "dir_unreadable") echo "Cannot read data/shared (check permissions)" ;;
+                "not_dir_or_link") echo "data/shared exists as a file. Linking would destroy it, so stopping" ;;
                 "recreate") echo "Recreate? [y/N]" ;;
                 "cancelled") echo "Cancelled" ;;
                 "local_exists") echo "data/local directory already exists" ;;
@@ -200,10 +224,73 @@ else
     echo "   data/local/debug/"
 fi
 
+# --- data/shared が symlink 以外で存在する場合のガード（#133） ---
+#
+# 以前は `-L`（symlink か）しか見ておらず、実ディレクトリのとき ln -sf が
+# **リンクをその中に**作っていた（data/shared/<basename>）。共有が成立せず、
+# worktree 削除でデータが失われる silent-wrong だった。
+mkdir -p data
+
+if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
+    if [ ! -d "data/shared" ]; then
+        # 実ファイル。ln -sf は黙って上書きするので必ず止める
+        error_msg="$(msg not_dir_or_link)"
+        echo -e "${RED}[ERROR]${NC} ${error_msg}: data/shared" >&2
+        exit 1
+    fi
+
+    if [ ! -r "data/shared" ]; then
+        echo -e "${RED}[ERROR]${NC} $(msg dir_unreadable)" >&2
+        exit 1
+    fi
+
+    # 旧バージョンが中に作った stray link を先に片付ける。
+    # 名前では判定しない（旧バグが作る名前は basename "$SHARED_DATA_PATH"）
+    for entry in data/shared/* data/shared/.*; do
+        [ -L "$entry" ] || continue
+        target=$(readlink "$entry")
+        if [ "$target" = "$SHARED_DATA_PATH" ]; then
+            rm -f "$entry"
+            warn "$(msg stray_link_removed): $entry"
+        fi
+    done
+
+    # 残りが空かどうかで分岐する。
+    # ★ .gitkeep はプレースホルダでありユーザーデータではない。
+    #   旧ポリシー（data/shared/** + !data/shared/.gitkeep）の派生プロジェクトでは
+    #   worktree 展開時に必ず .gitkeep が具現化するため、これをデータとして扱うと
+    #   **sync した瞬間に全 worktree 作成が止まる**（実測）
+    remaining=$(find data/shared -mindepth 1 \
+        -not -name '.DS_Store' -not -name '.gitkeep' -print -quit 2>/dev/null)
+    if [ -n "$remaining" ]; then
+        echo -e "${RED}[ERROR]${NC} $(msg dir_has_data)" >&2
+        echo "" >&2
+        echo "  $(msg move_data_first)" >&2
+        echo "    mkdir -p \"$SHARED_DATA_PATH\"" >&2
+        echo "    mv data/shared/* \"$SHARED_DATA_PATH\"/" >&2
+        echo "    rmdir data/shared" >&2
+        echo "" >&2
+        exit 1
+    fi
+
+    # 旧ポリシーからの移行案内。.gitkeep が追跡下にあると、ディレクトリを消した時点で
+    # ` D data/shared/.gitkeep` が残り続ける。黙って汚さず、直し方を示す
+    if git ls-files --error-unmatch data/shared/.gitkeep >/dev/null 2>&1; then
+        warn "$(msg gitkeep_tracked)"
+        echo "    cd \"$MAIN_REPO\" && git rm --cached data/shared/.gitkeep" >&2
+        echo "    bash scripts/ensure-gitignore.sh" >&2
+    fi
+
+    if ! rm -rf data/shared; then
+        echo -e "${RED}[ERROR]${NC} $(msg dir_remove_failed)" >&2
+        exit 1
+    fi
+    info "$(msg dir_replaced)"
+fi
+
 # Create symlink
 info "$(msg creating_symlink)"
-mkdir -p data
-ln -sf "$SHARED_DATA_PATH" data/shared
+ln -sfn "$SHARED_DATA_PATH" data/shared
 
 success "$(msg created): data/shared -> $SHARED_DATA_PATH"
 echo ""

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -39,6 +39,8 @@ msg() {
                 "symlink_exists") echo "data/shared シンボリックリンクは既に存在します" ;;
                 "stray_link_removed") echo "旧バージョンが作った不要なリンクを削除しました" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep が git 追跡下にあります。メインリポジトリで次を実行して移行してください:" ;;
+                "is_shared_store") echo "data/shared は共有データストアそのものです。ここでリンクを張ると共有データを失います" ;;
+                "move_conflict_note") echo "同名ファイルがある場合は -n により移動されません。残ったものは中身を確認してから手動で統合してください。" ;;
                 "dir_has_data") echo "data/shared がシンボリックリンクではなく実体のあるディレクトリで、中にデータがあります" ;;
                 "move_data_first") echo "そのままではリンクできません。次のコマンドで中身をメインリポジトリへ移してから再実行してください:" ;;
                 "dir_replaced") echo "空の data/shared ディレクトリを削除しました（シンボリックリンクに置き換えます）" ;;
@@ -73,6 +75,8 @@ msg() {
                 "symlink_exists") echo "data/shared 符号链接已存在" ;;
                 "stray_link_removed") echo "已删除旧版本创建的多余链接" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep 仍被 git 跟踪。请在主仓库中执行以下命令完成迁移:" ;;
+                "is_shared_store") echo "data/shared 就是共享数据存储本身。在此创建链接会丢失共享数据" ;;
+                "move_conflict_note") echo "如有同名文件，-n 会跳过移动。请检查剩余文件后手动合并。" ;;
                 "dir_has_data") echo "data/shared 是真实目录（非符号链接）且其中包含数据" ;;
                 "move_data_first") echo "当前状态无法创建链接。请用以下命令将内容移动到主仓库后重新执行:" ;;
                 "dir_replaced") echo "已删除空的 data/shared 目录（将替换为符号链接）" ;;
@@ -107,6 +111,8 @@ msg() {
                 "symlink_exists") echo "data/shared symlink already exists" ;;
                 "stray_link_removed") echo "Removed a stray link created by an older version" ;;
                 "gitkeep_tracked") echo "data/shared/.gitkeep is still tracked by git. Run these in the main repository to migrate:" ;;
+                "is_shared_store") echo "data/shared IS the shared data store. Linking here would destroy the shared data" ;;
+                "move_conflict_note") echo "Files with the same name are skipped by -n. Inspect what remains and merge manually." ;;
                 "dir_has_data") echo "data/shared is a real directory (not a symlink) and contains data" ;;
                 "move_data_first") echo "Cannot link as-is. Move its contents to the main repository and re-run:" ;;
                 "dir_replaced") echo "Removed the empty data/shared directory (replacing it with a symlink)" ;;
@@ -231,6 +237,22 @@ fi
 # worktree 削除でデータが失われる silent-wrong だった。
 mkdir -p data
 
+# ★ F-1: data/shared が**共有ストアそのもの**なら絶対に触らない。
+#   メインリポジトリで実行された場合（git worktree list の第1行なので worktree 判定を通る）、
+#   ここを消すと共有データを削除して自己参照 symlink を張り、
+#   以後 "Too many levels of symbolic links" で復旧不能になる。
+#   これは本 issue が塞ごうとしている silent-wrong と同型なので、最優先で止める
+if [ -d "data/shared" ] && [ ! -L "data/shared" ]; then
+    _here=$(cd data/shared 2>/dev/null && pwd -P || echo "")
+    _store=$(cd "$SHARED_DATA_PATH" 2>/dev/null && pwd -P || echo "")
+    if [ -n "$_here" ] && [ "$_here" = "$_store" ]; then
+        echo -e "${RED}[ERROR]${NC} $(msg is_shared_store)" >&2
+        echo "  data/shared = $_here" >&2
+        echo "  $(msg run_in_worktree)" >&2
+        exit 1
+    fi
+fi
+
 if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
     if [ ! -d "data/shared" ]; then
         # 実ファイル。ln -sf は黙って上書きするので必ず止める
@@ -260,15 +282,23 @@ if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
     #   旧ポリシー（data/shared/** + !data/shared/.gitkeep）の派生プロジェクトでは
     #   worktree 展開時に必ず .gitkeep が具現化するため、これをデータとして扱うと
     #   **sync した瞬間に全 worktree 作成が止まる**（実測）
-    remaining=$(find data/shared -mindepth 1 \
-        -not -name '.DS_Store' -not -name '.gitkeep' -print -quit 2>/dev/null)
+    # find が失敗する（辿れない・未対応の find 等）場合に無言終了しないこと。
+    # set -e 下では代入の失敗でそのまま落ち、理由が一切出なくなる
+    if ! remaining=$(find data/shared -mindepth 1 \
+        -not -name '.DS_Store' -not -name '.gitkeep' -print -quit 2>/dev/null); then
+        echo -e "${RED}[ERROR]${NC} $(msg dir_unreadable)" >&2
+        exit 1
+    fi
     if [ -n "$remaining" ]; then
         echo -e "${RED}[ERROR]${NC} $(msg dir_has_data)" >&2
         echo "" >&2
         echo "  $(msg move_data_first)" >&2
         echo "    mkdir -p \"$SHARED_DATA_PATH\"" >&2
-        echo "    mv data/shared/* \"$SHARED_DATA_PATH\"/" >&2
+        echo "    mv -n data/shared/* \"$SHARED_DATA_PATH\"/   # -n: 同名を上書きしない" >&2
+        echo "    mv -n data/shared/.[!.]* \"$SHARED_DATA_PATH\"/ 2>/dev/null || true  # 隠しファイル" >&2
         echo "    rmdir data/shared" >&2
+        echo "" >&2
+        echo "  $(msg move_conflict_note)" >&2
         echo "" >&2
         exit 1
     fi


### PR DESCRIPTION
Closes #133

PR #84（downstream 由来）の主眼だった **worktree のデータ保護が機能していない**問題を解消。#84 の退行部分は持ち込まず、symlink ガードと追跡ポリシーのみを取り込んだ。

## 問題
`ln -sf` は `data/shared` が実ディレクトリのときリンクを**その中に**作る（`data/shared/<basename>`）。共有が成立せず worktree 削除でデータが失われるのに、`[OK] Created` と表示する silent-wrong だった。

## 変更
- **根本原因の追跡ポリシーを修正**: `data/shared` 自体を ignore し `.gitkeep` を追跡から外す。`/**` ではパス自体にマッチせず、symlink 化した `data/shared` が未追跡として露出して**ホスト絶対パスがコミットされる**（検証で実際にステージされることを再現）
- **ガード**: 実ファイル→停止（従来は無警告で消えた）／データあり→停止＋移動案内／空→置換／stray link は `readlink` 一致で判定（名前非依存）
- **自己参照の防止**: `data/shared` が共有ストアそのものなら触らない（実在性に依存しないパス比較）
- 旧ポリシーの既存プロジェクトが sync 直後に止まらないよう `.gitkeep` はプレースホルダ扱いとし、移行手順を案内

## 検証
本物の git worktree で V1〜V11 全 PASS。3周の敵対的精査で、この変更自体が持ち込んだ silent-wrong 2件（F-1/F-6）を含む6件を検出・修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)