### PR TITLE
feat(devcontainer): コンテナの主プロセスを非 root にする (#141)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,9 +22,16 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # 非rootユーザーを作成（既存のUID/GIDがあれば再利用）
+# ★ USER_UID / USER_GID に既定値が必須（#141）。
+#   これらが空だと `getent group`（引数なし）が exit 0 を返すため、
+#   **vscode ユーザーが作られないままビルドが成功する**。
+#   末尾で `USER $USERNAME` に切り替えるようになったので、その状態のイメージは
+#   起動時に必ず `unable to find user vscode` で落ちる（以前は USER 行が無く root で動いていた）。
+#   compose 経由では `USER_UID: ${UID:-1000}` が渡るが、
+#   `docker build` を直接叩く経路（GPU の platform 指定ビルド等）では渡らない。
 ARG USERNAME=vscode
-ARG USER_UID
-ARG USER_GID
+ARG USER_UID=1000
+ARG USER_GID=1000
 RUN if getent group $USER_GID > /dev/null; then \
         EXISTING_GROUP=$(getent group $USER_GID | cut -d: -f1); \
     else \
@@ -48,8 +55,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # uv をインストール（高速Pythonパッケージマネージャー）
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
+# UV_INSTALL_DIR=/usr/local/bin: 既定の /root/.local/bin だと、末尾の USER 切り替え後に
+#   非 root から /root が読めず uv が消える（#141）。/usr/local/bin は既定 PATH に含まれるため
+#   ENV PATH の追記も不要になる。symlink での二重管理はインストール先と参照先が2箇所になり
+#   uv 更新時に片方だけ変わりうるため採らない（単一情報源の原則）
+# INSTALLER_NO_MODIFY_PATH=1: システムパスに入れる以上インストーラによる ~/.bashrc への
+#   PATH 追記は不要。root のホームに副作用を残さない
+RUN curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
 
 # Node.js 20をインストール（Claude Code用）
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
@@ -73,3 +86,26 @@ ARG INSTALL_TORCH_CPU=false
 RUN if [ "$INSTALL_TORCH_CPU" = "true" ]; then \
     pip install torch --index-url https://download.pytorch.org/whl/cpu; \
 fi
+
+# ============================================================
+# ここから非 root（#141）
+# ============================================================
+# USER が無いとコンテナの主プロセスが root で動く。devcontainer.json の
+# `remoteUser: vscode` は VS Code 経由のシェルにしか効かないため、
+# `docker compose run` / `docker exec` を直接叩くと root になり、
+# bind mount した /workspace（＝ホストのリポジトリ）に root 所有ファイルが残る。
+# macOS の Docker Desktop は UID を写像するため症状が出にくいが、
+# Linux ホストや共同研究者の環境では以後の git 操作・ファイル削除が権限エラーで止まる。
+#
+# 上流の apt-get / npm install -g / pip install は root が必要なため、
+# ビルド段階は root のままにし、**末尾でだけ**切り替える。
+# ユーザー名は上で定義した ARG USERNAME を再利用する（2箇所に書かない）。
+# sudo NOPASSWD は維持しており（#64 で見送りと判断済み）、
+# post-create.sh が依存する sudo 6箇所と docker-outside-of-docker feature の
+# socket 権限調整はそのまま動く。
+#
+# ★ 追加の RUN / COPY はこのブロックより**上**に置くこと。
+#   ここより下に書くと非 root で実行され、apt-get / npm -g / pip が権限エラーで落ちる。
+#   --- [Project] プロジェクト固有の追加インストールは、この行より上に追記 ---
+WORKDIR /workspace
+USER $USERNAME

--- a/.spec/issues/141-auto-decisions.md
+++ b/.spec/issues/141-auto-decisions.md
@@ -1,0 +1,126 @@
+# Issue #141 自動判断ログ
+
+## メタ情報
+- 判断日時: 2026-08-03
+- 自動処理: /task-run（親 task #139）
+- 判断対象: `.spec/issues/141-non-root-user.md`（コンテナ主プロセスの非 root 化）
+
+## 必読コンテキストの状態
+
+| ファイル | 状態 |
+|---|---|
+| `.spec/core-rules.md` | 既定節あり。**プロジェクト固有節は未記入** |
+| `.spec/invariants.md` | 既定節あり。**プロジェクト固有節は未記入** |
+| `.spec/known-issues.md` | 既定節あり。**プロジェクト固有節は未記入** |
+
+→ S1 非該当（既定節が揃っている）。プロジェクト固有のルールが未登録のため、
+既定のみで判断した。プロジェクト固有の失敗パターンは既定では捕捉できない。
+
+## ゴール書き換えチェック（最優先）
+
+親 task #139 の goal（成功条件 1〜5、negative の意味）を仕様と照合した。
+仕様は goal 条件4「主プロセスが非 root になり、/workspace に root 所有ファイルが
+残らない」および条件5の一部（uv PATH、CPU/GPU 起動）に対応する実装であり、
+**goal の範囲・成功条件の変更を含まない**。→ 書き換えなし。
+
+## 判断一覧
+
+### 1. D1: uv を UV_INSTALL_DIR=/usr/local/bin へ
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | 設計が妥当か。見落としている副作用はないか |
+| 判断 | ✅ 許可 |
+| 理由 | (a) `/usr/local/bin` は既定 PATH に含まれ、`ENV PATH="/root/.local/bin:..."` の削除で「USER 切替後に uv が消える」障害を根本解決する。対症療法（symlink 二重管理）を退けた理由が単一情報源の原則（dev-guidelines / R-D06 の趣旨）で明示されている。(b) `python:3.11-slim` での実測（インストール先・残骸なし・nobody からの実行成功）が記録済みで、推測ではなく検証に基づく。(c) 現物確認: post-create.sh / post-start.sh / compose に `/root/.local/bin` への参照は無く、削除による他の破壊は見当たらない。 |
+| 残る副作用（軽微・停止不要） | ① `uv self update` は /usr/local/bin が root 所有のため非 root では失敗する → NOPASSWD sudo（D3）で回避可能。② GPU ベースイメージ（nvcr.io/nvidia/pytorch）に uv が同梱されている場合は上書きになる → 挙動として問題なし。いずれも V7/V12 で検出可能 |
+| 参照 | `.spec/known-issues.md` KI-D06（fresh 環境での再現）、dev-guidelines「単一情報源の原則」、Dockerfile:50-52 現物 |
+| 自信度（参考記録） | 90% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+### 2. D2: 末尾で USER 切り替え（ビルドは root のまま）
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | 壊れる既存ワークフローがないか（features / updateRemoteUserUID / named volume / NVIDIA entrypoint） |
+| 判断 | ✅ 許可 |
+| 理由 | 指摘された4点を現物と照合した（下表）。既存パターン（Dockerfile:25 の `ARG USERNAME=vscode` を再利用、ユーザー名を2箇所に書かない）に沿っており、S5 非該当。 |
+| 参照 | `.devcontainer/Dockerfile`、`docker-compose.yml`、`cpu/gpu devcontainer.json`、`post-create.sh`、`post-start.sh` |
+| 自信度（参考記録） | 80% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+照合結果:
+
+| 懸念 | 照合結果 |
+|---|---|
+| devcontainer features | D4 の主張どおり、features は派生ビルドで root として導入される。`docker-outside-of-docker` の socket 権限調整スクリプトは非 root 時に sudo を使う実装であり、D3（NOPASSWD 維持）が前提として噛み合っている。**D3 を外すと D4 が崩れる**依存関係にある点は仕様に明示されていないが、両方とも維持されるため実害なし |
+| `updateRemoteUserUID: true` | remoteUser（vscode）が非 root であることが前提の機構であり、最終 USER の非 root 化とはむしろ整合する。compose が `USER_UID: ${UID:-1000}` を渡す既存経路も不変 |
+| named volume `/home/vscode/.claude` | 新規 volume は root 所有でマウントされうるが、post-create.sh:11 の `sudo chown -R` が既にこれを処理している（本変更の前から必要だった処理）。壊れない |
+| NVIDIA entrypoint | 非 root で完走するかは**未知**であり、仕様自身が「失敗と切り分け」表で「負の結果として記録」と定めている。これは goal の negative の意味（root 前提の結合の証拠）と正確に一致しており、R-D02 / experiment-discipline に適合 |
+| `WORKDIR /workspace` | 実行時は bind mount で上書きされるため所有権の問題なし |
+| post-create の sudo 6箇所 | D3 で NOPASSWD 維持のためそのまま動く。V10 が代理検証 |
+
+### 3. 検証チェックリスト V1〜V15 の十分性
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | 「非 root 化が本当に達成されたか」を測る項目として十分か |
+| 判断 | ⚠️ 警告付き許可（下記の追加項目を条件とする） |
+| 理由 | V1〜V15 は全項目 PASS/FAIL を機械的に判定でき、S4 非該当。ただし親 goal 条件4の**後半「/workspace に root 所有ファイルが残らない」を直接測る項目が無い**。V5（id -u ≠ 0）は前半の代理にすぎない。また V5〜V11 は素の `docker run` であり、背景に書かれた実際の障害経路（`docker compose run` / devcontainer 実経路）を通らない。goal 条件5「CPU / GPU 両方で devcontainer が起動する」に対する CPU 側の実経路確認（postCreate / features を含む）も欠けている |
+| 追加すべき項目 | V16: `docker compose run`（実際の compose 経路・entrypoint 込み）で `id -u` が 0 でない。V17: bind mount した /workspace 内にコンテナからファイルを作成し、**所有者が root でない**ことをホスト側から確認（goal 条件4後半の直接測定。macOS では UID 写像で偽陰性になり得るため、その旨を結果に併記する）。V18: `devcontainer up`（CPU）が完走する — features 導入・updateRemoteUserUID・postCreateCommand（sudo 6箇所）・postStartCommand（.bashrc 書込）を含む end-to-end 確認 |
+| 参照 | 親 task #139 goal 条件4・5、`.spec/known-issues.md` KI-D03（silent-wrong: クラッシュしないため気づかれない失敗の類型。macOS で症状が出ない本件と同型） |
+| 自信度（参考記録） | 75% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし（チェックリストは存在し判定可能。不足は追加で解消） |
+
+### 4. V12（GPU）が完走しない場合の「未検証」+ user-action 方針
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | S1〜S8 の停止条件に該当しないか |
+| 判断 | ✅ 許可（条件付き） |
+| 理由 | 停止条件に**該当しない**。むしろ R-D05（実行0件を「通っている」と扱わない）に正しく適合している。「`docker build が通った` と書かない」という明示は、silent-wrong 系の失敗（KI-D01〜D04 の教訓）を先回りで塞ぐもの。S6 についても、これは negative を結論にする提案ではなく「未検証」を未検証のまま保留する提案であり、experiment-discipline の `unverified-negative` の扱いと同型で適合 |
+| 条件 | ① V12 未検証のまま issue #141 を完了扱いにする場合、**user-action ラベル付きの follow-up issue を必ず起票**し、#141 と親 #139 の双方に「GPU は未検証」を明記すること。② 親 task #139 を閉じる際は goal 条件5（GPU 起動）が未充足のままになるため、その時点で **S7 の照合を改めて行う**（本判断は #141 の仕様の承認であり、#139 のクローズを承認するものではない） |
+| 参照 | `.spec/core-rules.md` R-D02 / R-D05、`.claude/rules/template/experiment-discipline.md` §4、labels.md（user-action = 自動処理でスキップ） |
+| 自信度（参考記録） | 85% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし（S7 は #139 クローズ時に再照合） |
+
+### 5. スコープ外項目（NOPASSWD 維持など）が goal を小さく読んでいないか
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | スコープ外の設定が goal の範囲を勝手に狭めていないか |
+| 判断 | ✅ 許可 |
+| 理由 | スコープ外4項目を goal 条件 1〜5 と1項目ずつ照合した。(a) NOPASSWD 維持: goal 条件4は「主プロセスの非 root 化」であり sudo の除去ではない。goal の negative の意味の節が「post-create の sudo 6箇所」を維持対象のワークフローとして明示しており、維持は goal と整合する。#64 での見送り判断も引用されている。(b) checksum 検証: goal 条件のいずれにも該当せず、#64 で判断済み。(c) `ENV PATH=/usr/bin`: Node.js 優先の既存設定で本件と独立。(d) docker-outside-of-docker: セキュリティ方針変更で goal 外。いずれも「先行の判断を根拠に後続を落とす」形ではなく、goal に無いものを goal に無いと言っているだけである |
+| 参照 | 親 task #139 goal 原文、`docs/security.md` §7（NOPASSWD = 低リスク・devcontainer 標準） |
+| 自信度（参考記録） | 90% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし（S8: 落とされた項目はいずれも親の完了条件に無いことを原文照合で確認） |
+
+### 6. Fallback ホワイトリスト（なし）
+
+| 項目 | 内容 |
+|------|------|
+| 質問 | Fallback なしの宣言は妥当か |
+| 判断 | ✅ 許可 |
+| 理由 | 「駄目なら root で続行」を明示的に禁止しており、R-D01（前提が崩れた入力を黙って受理しない）・KI-D03 に正しく適合。目的を無効化するフォールバックを入れない判断は保守的で正しい |
+| 参照 | `.spec/core-rules.md` R-D01、`.spec/known-issues.md` KI-D03 |
+| 自信度（参考記録） | 95% ※停止判定には使用しない |
+| 停止条件チェック | 該当なし |
+
+## 総合判定
+
+**⚠️ 警告付き許可**（実装へ進んでよい）
+
+条件:
+1. 検証チェックリストに V16〜V18（判断3）を追加すること
+2. V12 未検証で完了する場合は user-action の follow-up issue を起票し、#141 / #139 に「GPU 未検証」を明記すること（判断4）
+3. 親 task #139 のクローズ時に goal 条件5 の充足を S7 で再照合すること
+
+## 停止判断
+
+該当なし（S1〜S8 のいずれにも該当しない）。
+
+## 要確認フラグ（停止には至らないが不確実性が残る項目）
+
+- [ ] D4（features は影響を受けない）は D3（NOPASSWD 維持）に依存する。将来 NOPASSWD を外す変更をする際は docker-outside-of-docker の socket 権限調整が壊れる可能性を再評価すること
+- [ ] `uv self update` は /usr/local/bin が root 所有のため非 root では失敗する（sudo で回避可能。実害は小さいが、ユーザーが踏んだら docs に注記する）
+- [ ] V17 は macOS ホストでは UID 写像により偽陰性になり得る。Linux ホストでの確認が取れない場合はその旨を結果に併記する
+- [ ] `.spec/` 3ファイルのプロジェクト固有節が未記入のまま判断した（既定のみで判断）

--- a/.spec/issues/141-non-root-user.md
+++ b/.spec/issues/141-non-root-user.md
@@ -1,0 +1,346 @@
+# Issue #141 仕様: コンテナの主プロセスを非 root にする（USER / WORKDIR）
+
+- 状態: approved（auto-reviewer 判断済み＝警告付き許可。V16〜V18 を追加。ログ: 141-auto-decisions.md）
+- 出自: #64 の項目4 / 親 task #139
+
+## 背景
+
+`.devcontainer/Dockerfile` に `USER` 指示が無く、**コンテナの主プロセスが root** で動く。
+`devcontainer.json` の `remoteUser: vscode` は VS Code 経由のシェルにしか効かないため、
+`docker compose run` / `docker exec` を直接叩くと root になり、
+**root 所有のファイルが `/workspace`（＝ホストのリポジトリ）に残る**。
+
+Linux ホストや共同研究者の環境では、その後の `git` 操作やファイル削除が
+権限エラーで止まる。macOS の Docker Desktop は UID を写像するため症状が出にくく、
+**テンプレート開発環境では見えない失敗モード**である（#135 と同型）。
+
+## 既知の障害: uv が root 専用パスにある
+
+```dockerfile
+# Dockerfile:50-52（現状）
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+```
+
+インストーラを root で走らせているため uv は `/root/.local/bin` に入る。
+`USER vscode` を足すだけでは **`/root` が非 root から読めず uv が消える**。
+「USER を1行足すだけ」と見積もると必ず踏む。
+
+## 設計
+
+### D1: uv をシステム共有パスに入れる（PATH 追記をやめる）
+
+```dockerfile
+RUN curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
+```
+
+**PATH を書き換えずに解決する。** `/usr/local/bin` は既定 PATH に含まれるため、
+`ENV PATH="/root/.local/bin:${PATH}"` の行を**削除できる**。
+
+**★ 実測で確認済み**（`python:3.11-slim`、本 issue 着手時）:
+
+| 確認項目 | 結果 |
+|---|---|
+| インストール先 | `/usr/local/bin/uv`, `/usr/local/bin/uvx` |
+| `/root/.local/bin` の残骸 | **無し**（ディレクトリごと作られない） |
+| 非 root（`nobody`）からの実行 | `uv 0.12.1` — **PATH 設定なしで成功** |
+
+`INSTALLER_NO_MODIFY_PATH=1` は、インストーラが `~/.bashrc` 等へ PATH 追記するのを止める。
+システムパスに入れる以上その追記は不要で、**root のホームに副作用を残さない**ため付ける。
+
+**代替案を採らない理由**: 「`/root/.local/bin` に入れてから `/usr/local/bin` へ symlink」は、
+インストール先と参照先が2箇所になり、uv 更新時に片方だけ変わりうる（単一情報源の原則に反する）。
+
+### D2: ビルドは root、最終 USER のみ非 root
+
+`apt-get` / `npm install -g` / `pip install` は root が必要なので、**ビルド段階は root のまま**。
+Dockerfile の**末尾**で切り替える。
+
+```dockerfile
+WORKDIR /workspace
+USER $USERNAME
+```
+
+`USERNAME` は既に `ARG USERNAME=vscode`（Dockerfile:25）で定義済みで、
+同一ステージの後続命令から参照できる。**ユーザー名を2箇所に書かない。**
+
+### D3: `NOPASSWD` は残す
+
+`post-create.sh` は sudo に6箇所依存する（`chown` / `tee /etc/machine-id` /
+`sed -i /etc/bash.bashrc` / `npm i -g` / `ln -sf /usr/local/bin` / `tee /etc/profile.d`）。
+#64 の判断で `NOPASSWD:ALL` は残すため、これらは**そのまま動く**。
+
+### D4: features は影響を受けない
+
+`docker-outside-of-docker` 等の devcontainer features は、devcontainer CLI が
+Dockerfile の**後段**に `USER root` を挟んで導入し、その後 `containerUser` に戻す。
+本変更で feature のインストールが壊れることはない。
+
+## 変更しないもの（スコープ外）
+
+| 対象 | 理由 |
+|---|---|
+| `NOPASSWD:ALL` | #64 の項目1。**見送りと判断済み**（コメントに根拠を記録） |
+| `curl \| sh` の checksum 検証 | #64 の項目2。見送りと判断済み |
+| `ENV PATH="/usr/bin:${PATH}"`（Dockerfile:60） | Node.js 優先のための既存設定。本 issue と無関係 |
+| `docker-outside-of-docker` feature | 無効化はセキュリティ方針の変更であり、親 task の goal 外 |
+
+## Fallback ホワイトリスト
+
+**なし。** 本 issue に条件分岐フォールバックを導入しない。
+`USER` の切り替えは成功/失敗が二値であり、「駄目なら root で続行」は
+**目的そのものを無効化する**ため許可しない。
+
+## 検証チェックリスト
+
+静的（コード確認）:
+
+- [x] V1: Dockerfile の最終 `USER` が `$USERNAME`（非 root）である
+- [x] V2: `WORKDIR /workspace` がある
+- [x] V3: `ENV PATH="/root/.local/bin:${PATH}"` が**削除**されている
+- [x] V4: uv のインストール先指定が1箇所だけ（symlink 等の二重管理が無い）
+
+動的（**CPU イメージで実測**。`docker build` ＋ `docker run`）:
+
+`docker compose ... build` = **EXIT 0**（`torch-2.13.0+cpu` を導入、Dockerfile の全17ステップ完走。
+compose は末尾に `LABEL com.docker.compose.image.builder` を1つ足すのでログ上は18と表示される）。
+
+- [x] V5: `id -u` = **502**、`whoami` = `vscode`（root でない）
+- [x] V6: `pwd` = `/workspace`
+- [x] V7: `uv --version` = `uv 0.12.1`、`command -v uv` = `/usr/local/bin/uv`
+- [x] V8: `claude --version` = `2.1.197 (Claude Code)`
+- [x] V9: `gh --version` = `gh version 2.97.0`
+- [x] V10: `sudo -n true` 成功
+- [x] V11: `python -c "import torch"` = `2.13.0+cpu`
+- [x] 追加: `echo $PATH` に `/root/.local` を含まない（D1 の残骸が無いことの確認）
+
+GPU イメージ:
+
+- [x] V12: GPU ベースイメージでも同じ検証が通る（**一部未検証あり**。下記「V12 の結果」を参照）
+
+**★ V12 の実行可能性**: 本ホストは `linux/arm64`、GPU ベースイメージ
+`nvcr.io/nvidia/pytorch:24.12-py3` は `linux/amd64` のみ。エミュレーションで試行するが、
+**完走しない場合は「未検証」と明記して user-action に回す。**
+`docker build が通った` と**書かない**。実行していない検証を通過扱いにしない。
+
+ドキュメント:
+
+- [x] V13: `docs/devcontainer-internals.md` が実装と一致（Step 4-2 の指摘3件を反映後）
+- [x] V14: `docs/security.md` の `sudo NOPASSWD` / コンテナ隔離の記述が実装と一致
+  （Step 4-2 で**誤記2件**を指摘され修正。下記 F4 参照）
+
+- [x] V15: `quality-check.sh` PASS（実行4件 / 未実行3件。shellcheck はホスト未導入・本 issue は
+  シェルスクリプトを変更していない）
+
+### auto-reviewer が追加した検証項目（許可の条件）
+
+- [x] V16: **`docker compose run` 経路**で `id -u` ≠ 0。
+  V5〜V11 は素の `docker run` だが、**背景に書いた実際の障害経路は compose 直叩き**である。
+  entrypoint（GPU の NVIDIA entrypoint 含む）を通る経路を測っていないと、
+  「直したはずの経路」を検証していないことになる
+- [ ] V17: bind mount した `/workspace` にコンテナからファイルを作り、
+  **ホスト側から見た所有者が root でない**ことを確認する。
+  goal 条件4の後半「`/workspace` に root 所有ファイルが残らない」の**直接測定**。
+  **★ macOS の Docker Desktop は UID を写像するため、ここは偽陰性になりうる**
+  （root で作っても host 側でホストユーザー所有に見える）。
+  その場合は「この環境では判定不能」と記録し、PASS と書かない
+- [x] V18: **`devcontainer up`（CPU）が完走する**。
+  features の導入、`updateRemoteUserUID`、`postCreateCommand`（sudo 6箇所）、
+  `postStartCommand` を含む end-to-end 確認。goal 条件5の CPU 側に対応する
+
+## 実測の結果
+
+### V12（GPU）の結果: **ビルドと非 root 起動は実測 PASS。GPU デバイス接続は未検証**
+
+`nvcr.io/nvidia/pytorch:24.12-py3`（amd64、33.3GB）を `--platform linux/amd64` で取得し、
+エミュレーションでビルド・実行した。**当初の見込み（完走しないかもしれない）に反して完走した。**
+
+`docker build --platform linux/amd64 ... = EXIT 0`（全17ステップ）。実行結果:
+
+| 確認 | 結果 |
+|---|---|
+| `id -u` / `whoami` | **1000** / `vscode` |
+| `pwd` | `/workspace` |
+| `command -v uv` | `/usr/local/bin/uv` — `uv 0.12.1 (x86_64-unknown-linux-gnu)` |
+| `claude --version` | `2.1.197` |
+| `gh --version` | `2.97.0` |
+| `sudo -n true` | 成功 |
+| `import torch` | `2.6.0a0+df5bbc09d1.nv24.12`（ベースイメージ同梱版のまま） |
+| PATH に `/root/.local` | 含まれない |
+
+**最大のリスクだった「NVIDIA entrypoint が root 前提ではないか」は否定された。**
+`/opt/nvidia/nvidia_entrypoint.sh` は非 root で正常に動作する。
+
+**★ 未検証（正直に記録する）**:
+
+- **GPU デバイスへの実接続（`nvidia-smi`）は検証していない。** 本ホストに NVIDIA GPU が無い
+  （起動時に `WARNING: The NVIDIA Driver was not detected` が出る）。
+  これは環境の制約であり、本変更の成否とは独立
+- **`compose` 経由の GPU ビルドは通らなかった。** ただし原因は本変更と無関係で、
+  ホストの docker に **buildx が入っておらず legacy builder が `--platform` を扱えない**ため
+  （`NotFound: content digest ... not found`）。`docker build --platform` を直接叩くと通る。
+  実 GPU ホスト（amd64）では platform 指定自体が不要なので、この失敗は再現しない
+- GPU 側の `devcontainer up`（features 込みの end-to-end）は未実行
+
+### V17 は **この環境では判定不能**（PASS と書かない）
+
+`docker compose run` でコンテナ内から `/workspace/data/local/` にファイルを作り、
+ホスト側から所有者を見た結果:
+
+| コンテナ内のユーザー | コンテナから見た所有者 | **ホストから見た所有者** |
+|---|---|---|
+| `vscode`（uid 502） | `502 20` | `502 20` |
+| **`root`（uid 0）— 対照実験** | `0 0` | **`502 20`** |
+
+**root で作ったファイルもホストからはホストユーザー所有に見える。**
+macOS Docker Desktop（VirtioFS）が UID を写像するためで、
+**この測定には検出力が無い**（変更前でも同じ結果になる）。
+
+対照実験を置かずに上段だけを見れば「非 root 化できた証拠」に見えたはずで、
+これは `experiment-discipline.md` の言う「positive/sanity control が無い null」と同型です。
+**検出力の無いテストを PASS と書かない。**
+
+goal 条件4の後半「`/workspace` に root 所有ファイルが残らない」は、
+**Linux ホストでのみ判定可能**です（bind mount が UID をそのまま通すため）。
+そちらは user-action として残します。
+
+### V18 の実測内容（`devcontainer up`、CPU）
+
+`{"outcome":"success", "remoteUser":"vscode", "remoteWorkspaceFolder":"/workspace"}`。
+起動後のコンテナ内で確認:
+
+| 確認 | 結果 |
+|---|---|
+| `id` | `uid=502(vscode) gid=20(dialout) groups=20(dialout),**991(docker)**` |
+| `pwd` | `/workspace` |
+| `uv` | `/usr/local/bin/uv` — `uv 0.12.1` |
+| `sudo -n id -u` | `0`（post-create.sh の sudo 6箇所が動く） |
+| `docker --version`（feature） | `29.7.1` — **feature の導入は壊れていない**（D4 の確認） |
+| `/home/vscode/.claude` の所有者 | `vscode`（named volume ＋ post-create の chown が機能） |
+| `.bashrc` の `claude-skip-permissions` | 1 件（post-start.sh が機能） |
+
+**★ 副次的に判明した事実（#64 の訂正の裏付け）**: 非 root ユーザーが
+**`docker` グループ（991）に入っています**。`docker-outside-of-docker` feature が
+そう設定するためで、**sudo 無しでホストの Docker socket に到達できます**。
+「NOPASSWD を消せばホスト脱出を塞げる」が成立しないことの実測証拠であり、
+#64 に投稿した訂正コメントの内容と一致します。
+
+### auto-reviewer からの申し送り
+
+- **D4（features が無事）は D3（NOPASSWD 維持）に依存する。**
+  `docker-outside-of-docker` は非 root 時に socket の権限調整で sudo を使う。
+  本 issue では両方維持するので実害は無いが、**将来 NOPASSWD を外すときは
+  この依存を先に解消すること**（#64 の再検討条件に連動）
+- `uv self update` は `/usr/local/bin` への書き込みになるため非 root では失敗する。
+  `sudo uv self update` で回避可能。実運用上の影響は小さいが既知の副作用として記録する
+- 本判断は **#139 のクローズ承認ではない。** goal 条件5（GPU 起動）は
+  task のクローズ判定時に S7 で改めて照合すること
+
+## 想定される失敗と切り分け
+
+| 症状 | 疑うもの |
+|---|---|
+| `uv: command not found` | D1 の PATH。`/root/.local/bin` の ENV が残っていないか |
+| GPU で起動しない | NVIDIA entrypoint が root 前提。**負の結果として記録**し root 前提の結合を報告 |
+| `/workspace` に書けない | ホスト側 UID と `USER_UID` の不一致（下記 F2） |
+| `unable to find user vscode` | `USER_UID` / `USER_GID` が空のままビルドされた（下記 F1） |
+
+## 検証で見つかった問題と対処（Step 4-2 の敵対的レビュー）
+
+### F1: `ARG USER_UID` に既定値が無く、**本 issue が起動不能の退行を持ち込んでいた**
+
+`Dockerfile:26-27` は `ARG USER_UID` / `ARG USER_GID` を**既定値なし**で宣言していた。
+build-arg を渡さずにビルドすると `getent group`（引数なし）が exit 0 を返すため、
+**vscode ユーザーが作られないままビルドが成功する。**
+
+変更前は `USER` 行が無かったので root で普通に起動していた（症状が出なかった）。
+`USER $USERNAME` を足したことで、この経路のイメージは
+**起動時に必ず `unable to find user vscode` で落ちる**ようになった。
+
+compose 経由なら `USER_UID: ${UID:-1000}` が渡るので踏まないが、
+**V12 の GPU 検証では `docker build --platform` を直接叩いており、現にこの経路を使っている。**
+
+→ **対処**: `ARG USER_UID=1000` / `ARG USER_GID=1000` と既定値を付け、理由をコメントに残した。
+
+### F2: `${UID:-1000}` は既定のシェルでは**常に 1000**になる（既存の問題。本 issue で顕在化）
+
+`docker-compose.yml:15-16` の `USER_UID: ${UID:-1000}` は、`UID` が
+**エクスポートされていないと機能しない**。zsh / bash とも既定ではエクスポートしないため、
+素の `docker compose build` では常に 1000:1000 になる。
+
+**V5 / V16 / V17 / V18 で記録した 502:20 は、既定手順の再現値ではない**（実行時に
+`UID` / `GID` を明示的に渡していたことによる）。
+**同じ文書内に 502 と 1000 の両方が出てくるのはこのため**で、
+build-arg を渡したかどうかの違いである（F1 の再検証と F3 の測定は渡していないので 1000）。
+明記しておかないと追試した人が値の差で混乱する。
+
+実害: **Linux ホストで uid≠1000 のユーザーが `docker compose run` を使うと `/workspace` に
+書けなくなる**（変更前は root だったので書けていた）。
+
+→ **対処**: 本 issue では**直さない**。compose 単体では UID を検出できず、
+修正は「ホスト側で `export UID GID` させる」等の運用要求か compose 構成の変更になり、
+**#141 のスコープ（非 root 化）を超える**。事実として記録し、必要なら別 issue にする。
+
+**★ 「主経路では問題が出ない」と書きかけたが、それは言えない（F4 と同じ誤りの再発）。**
+一度は「`devcontainer up` 経由では問題が出ないことを V18 で確認済み」と書いた。しかし
+**V18 は macOS での測定で、UID 写像により誰がどう作っても書けてしまう**。V17 と同じく
+**検出力ゼロ**であり、F2 の実害（Linux ホストで uid≠1000）を検出できる測定ではない。
+
+正しくは: **Linux ホストでは `updateRemoteUserUID: true` が UID を合わせるはずだが、未測定。**
+実際、macOS での実測では `devcontainer up` 後も `uid=1000`（ホストは 502）のままで、
+**`updateRemoteUserUID` は発火していない**（CLI 仕様どおり Linux ホスト限定の機構）。
+この確認も **#142（user-action）** の対象に含まれる。
+
+### F3: 「docker socket に到達できる」は**推論であって実測ではなかった**
+
+V18 で `groups=...,991(docker)` を観測し、そこから「sudo 無しで socket に到達できる」と
+書いていたが、これはグループ所属からの**推論**。実際に `docker ps` を通していない。
+この主張は #64 の訂正コメントの根拠として使っているため、**実測で裏を取る**。
+
+**F3 の実測**（修正後の `devcontainer up` で起動したコンテナ内、`sudo` を一切使わず）:
+
+```
+$ id
+uid=1000(vscode) gid=1000(vscode) groups=1000(vscode),991(docker)
+
+$ docker ps --format '{{.Names}}'      # sudo なし
+issue141_devcontainer-devcontainer-1
+com_bio_vag_visualization_devcontainer-devcontainer-1
+devcontainer-devcontainer-1            # ← 他プロジェクトのコンテナまで見える
+
+$ docker run --rm -v /:/host alpine:latest ls /host    # sudo なし
+Users  Volumes  bin  boot  ...
+```
+
+**推論ではなく実測として確認できた。** 非 root の `vscode` は sudo 無しで
+Docker API を叩け、任意のパスを mount した新しいコンテナを起動できる。
+`NOPASSWD` を外してもこの経路は塞がらない、という #64 の訂正の根拠が裏付けられた。
+
+**★ 表現の精度**: この `-v /:/host` で見えているのは **Docker Desktop の Linux VM の
+ルート**であって macOS のファイルシステムそのものではない。
+ただし Linux ホストではこれが**ホストの `/` そのもの**になる。
+いずれにせよ **devcontainer の隔離からは抜けている。**
+
+### F4: `docs/security.md` に**未検証の断定**と**事実誤り**を書いていた
+
+Step 4-2 の敵対的レビューで指摘された2件。どちらも本 issue の規律面の価値を損なうもの。
+
+1. **「root 権限は `sudo` を明示したときだけ得られます」は誤り。**
+   `docker exec -u 0` / `docker run --user root` で sudo 無しに root になれる。
+   **`USER` 指定は既定値であって境界ではない。** セキュリティ文書で保証範囲を
+   過大に書くのは、`|| true` で失敗を隠すのと同種の害がある
+2. **「`/workspace` に root 所有ファイルが残らない」を緩和要因として断定していた。**
+   これは V17 で「この環境では判定不能」と記録した内容そのもので、
+   **仕様側で踏みとどまった判断がドキュメント側で既成事実に格上げされていた。**
+   しかも §7 は `sudo NOPASSWD` の節であり、**sudo で破れる主張を
+   sudo のリスクの緩和要因に挙げる**という構造的矛盾でもあった
+
+→ **対処**: 「既定では非 root」「保証ではなく既定の改善」に書き換え、
+`-u 0` で root になれることを明記した。
+
+### F5: GPU 実機の未測定分は user-action issue に切り出した
+
+auto-reviewer の承認条件だった follow-up 起票が未了だったため、**#142** を起票し
+`validation` ＋ `user-action` ラベルを付けて #139 の子にリンクした。
+`user-action` は `/task-run` の自動処理でスキップされる。

--- a/docs/claude-san.md
+++ b/docs/claude-san.md
@@ -82,8 +82,12 @@ DevContainer を使用している場合、`claude-san` と `autoclaude` は Doc
 | | `claude` | `claude-san` |
 |---|---------|-------------|
 | tmux | なし | あり |
-| rate limit 自動再開 | なし | あり（autoclaude） |
+| rate limit 自動再開 | あり（`claude-auto-retry`） | あり（`claude-auto-retry`） |
 | セッション永続化 | ターミナル閉じで終了 | tmux でバックグラウンド継続 |
-| 権限確認 | alias で skip | skip |
+| 権限確認 | シェル関数で skip | skip |
 
-> **Note**: Dockerfile の alias 設定により、`claude` も `--dangerously-skip-permissions` 付きで起動します。権限確認の動作は同じです。
+> **Note**: `claude` も `--dangerously-skip-permissions` 付きで起動するため、権限確認の動作は同じです。
+> 付与しているのは **`post-start.sh` が `.bashrc` に注入する `claude()` シェル関数**です
+> （`# claude-skip-permissions` マーカー付きブロック）。
+> かつては Dockerfile の alias で付与していましたが、`claude-auto-retry` の `claude()` 関数と
+> 競合するため廃止済みです。詳細は [docs/devcontainer-internals.md](devcontainer-internals.md) を参照。

--- a/docs/devcontainer-internals.md
+++ b/docs/devcontainer-internals.md
@@ -6,7 +6,7 @@
 
 DevContainer は以下を自動的にセットアップします：
 
-- Claude Code + autoclaude のインストール
+- Claude Code + claude-auto-retry のインストール
 - CPU / GPU の自動切り替え（docker-compose による構成分離）
 - Git / GitHub CLI の認証引き継ぎ
 - Claude Code の認証永続化（コンテナ再ビルド後もログイン不要）
@@ -17,7 +17,8 @@ DevContainer は以下を自動的にセットアップします：
 .devcontainer/
 ├── Dockerfile                        # [Template] 共通イメージ（CPU/GPU対応）
 ├── docker-compose.yml                # [Template] 共通サービス定義
-├── post-create.sh                    # [Template] 共通ライフサイクル処理
+├── post-create.sh                    # [Template] 共通ライフサイクル処理（コンテナ作成後に1回）
+├── post-start.sh                     # [Template] 共通ライフサイクル処理（コンテナ起動ごと）
 ├── cpu/
 │   ├── devcontainer.json             # CPU固有設定
 │   └── docker-compose.override.yml   # CPU override（BASE_IMAGE等）
@@ -26,7 +27,7 @@ DevContainer は以下を自動的にセットアップします：
     └── docker-compose.override.yml   # GPU override（nvidia, shm等）
 ```
 
-**設計方針**: CPU と GPU で共通の設定は `docker-compose.yml`、`Dockerfile`、`post-create.sh` に集約し、差分のみを各 `override.yml` と `devcontainer.json` に記述します。
+**設計方針**: CPU と GPU で共通の設定は `docker-compose.yml`、`Dockerfile`、`post-create.sh`、`post-start.sh` に集約し、差分のみを各 `override.yml` と `devcontainer.json` に記述します。
 
 ### `[Template]` / `[Project]` タグ
 
@@ -56,17 +57,32 @@ FROM ${BASE_IMAGE}
 | gh (GitHub CLI) | Issue/PR 操作 |
 | Node.js 20 | Claude Code の実行環境 |
 | Claude Code | AI コーディングアシスタント |
-| autoclaude | Rate limit 自動再開（マルチアーキテクチャ対応） |
+| uv | 高速 Python パッケージマネージャー |
+| claude-auto-retry | Rate limit 自動再開（`post-create.sh` で npm から導入） |
 | tmux | セッション管理（claude-san用） |
 | jq, ripgrep, fzf | 検索・データ処理 |
 
-### claude の alias
+### uv のインストール先
 
 ```dockerfile
-RUN echo 'alias claude="claude --dangerously-skip-permissions"' >> /etc/bash.bashrc
+RUN curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin INSTALLER_NO_MODIFY_PATH=1 sh
 ```
 
-`claude` コマンド実行時に自動的に `--dangerously-skip-permissions` を付与。セキュリティへの影響は [docs/security.md](security.md) を参照。
+`uv` はシステム共有パス `/usr/local/bin` に入れます。ここは既定の `PATH` に含まれるため、
+`ENV PATH` の追記は不要です。インストーラ既定の `/root/.local/bin` に置くと、
+後述の `USER vscode` 切り替え後に非 root から `/root` が読めず `uv: command not found` になります（#141）。
+
+**既知の副作用**: `/usr/local/bin` は root 所有のため、`uv self update` は非 root では失敗します。
+`sudo uv self update` を使ってください。
+
+### `claude` の実行時オプション
+
+`--dangerously-skip-permissions` は **Dockerfile では付与していません**。
+以前あった `/etc/bash.bashrc` への alias は、claude-auto-retry が定義する `claude()`
+シェル関数と競合するため廃止しました（`post-create.sh` が旧 alias の残骸を除去します）。
+現在の付与箇所は `post-start.sh` の `claude()` ラッパーと `claude-san` の2つです。
+セキュリティへの影響は [docs/security.md](security.md) を参照。
 
 ### CPU-only PyTorch
 
@@ -78,6 +94,29 @@ fi
 ```
 
 GPU ベースイメージには PyTorch が含まれていますが、CPU イメージには含まれないため、`INSTALL_TORCH_CPU=true` で CPU 版 PyTorch をインストールします。
+
+### 非 root ユーザー（Dockerfile 末尾の `USER`）
+
+```dockerfile
+WORKDIR /workspace
+USER $USERNAME     # ARG USERNAME=vscode（上部で定義済み）
+```
+
+**コンテナの主プロセスは非 root（`vscode`）です。**
+
+`devcontainer.json` の `remoteUser: vscode` は VS Code 経由のシェルにしか効きません。
+Dockerfile に `USER` が無いと、`docker compose run` / `docker exec` を直接叩いたときに
+root になり、bind mount した `/workspace`（＝ホストのリポジトリ）に
+**root 所有のファイルが残ります**。Linux ホストや共同研究者の環境では、その後の
+`git` 操作やファイル削除が権限エラーで止まります（macOS の Docker Desktop は
+UID を写像するため症状が出にくく、気づかれにくい失敗モードです）。
+
+`apt-get` / `npm install -g` / `pip install` は root が必要なので、
+**ビルド段階は root のまま**にし、切り替えは Dockerfile の末尾でだけ行います。
+devcontainer features は devcontainer CLI が後段で `USER root` を挟んで導入するため、
+この変更の影響を受けません。
+
+root が必要な操作は `sudo`（NOPASSWD、`docs/security.md` §7）で行います。
 
 ## docker-compose の構成
 
@@ -135,10 +174,10 @@ services:
 
 ### post-create.sh
 
-コンテナ作成後に実行される共通処理：
+コンテナ作成後に1回だけ実行される共通処理：
 
 ```bash
-# 1. Claude 設定ディレクトリの所有権修正
+# 1. Claude 設定ディレクトリの所有権修正（Named Volume は root 所有でマウントされうる）
 sudo chown -R "$(id -u):$(id -g)" /home/vscode/.claude
 
 # 2. Claude の設定ファイルシンボリックリンク
@@ -147,9 +186,49 @@ ln -sf /home/vscode/.claude/.claude.json /home/vscode/.claude.json
 # 3. 決定論的 machine-id の生成
 echo -n "devcontainer-${PROJECT_NAME}" | md5sum | cut -c1-32 | sudo tee /etc/machine-id > /dev/null
 
-# 4. claude-san のシンボリックリンク
-sudo ln -sf "$(pwd)/claude-san" /usr/local/bin/claude-san
+# 4. TZ が未設定なら /etc/timezone から /etc/profile.d/tz.sh へ書き出す
+#    （claude-auto-retry がレート制限の再開時刻をパースするために必要）
+
+# 5. 旧 Dockerfile の claude alias が残っていれば除去し、claude-auto-retry を導入
+#    （alias が無い環境でも止まらないよう失敗を許容している）
+sudo sed -i '/alias claude=/d' /etc/bash.bashrc 2>/dev/null || true
+if ! command -v claude-auto-retry &> /dev/null; then
+  sudo npm i -g claude-auto-retry
+fi
+
+# 6. claude-san のシンボリックリンク（存在するときのみ）
+#    claude-san は install.sh 経由の派生プロジェクトには配布されないため、
+#    ガードしないと壊れた symlink が無言で作られる
+if [ -f "$(pwd)/claude-san" ]; then
+  sudo ln -sf "$(pwd)/claude-san" /usr/local/bin/claude-san
+fi
+
+# 7. worktree の .git 参照を相対パス化（ホスト/コンテナ間でパスが異なるため）
+#    スクリプトが無い派生プロジェクトでも止まらないようガードしている
+if [ -x ./scripts/configure-worktree-paths.sh ]; then
+  ./scripts/configure-worktree-paths.sh || true
+fi
 ```
+
+`sudo` を使う処理があるのは、`postCreateCommand` が**以前から** `vscode`（非 root）として
+実行されるためです（`devcontainer.json` の `remoteUser`）。
+`USER vscode` の追加（#141）はこの前提を変えていません。変わったのは
+**VS Code を経由しない `docker exec` / `docker compose run` の既定ユーザー**です。
+
+### post-start.sh
+
+コンテナ起動ごとに実行される共通処理：
+
+```bash
+# claude-auto-retry: .bashrc に claude() シェル関数を注入
+claude-auto-retry install
+
+# --dangerously-skip-permissions を常に付与する claude() ラッパーを
+# .bashrc へ追記（# claude-skip-permissions マーカー付きブロック）
+```
+
+`postCreateCommand` ではなく `postStartCommand` で行うのは、`postCreateCommand` の時点では
+`updateRemoteUserUID` により `.bashrc` が上書きされる可能性があるためです。
 
 プロジェクト固有の追加セットアップは `devcontainer.json` の `postCreateCommand` で `post-create.sh` の後に追記します：
 
@@ -237,15 +316,19 @@ export DEVCONTAINER_HOSTNAME=myproject
 ```jsonc
 // cpu/devcontainer.json
 "initializeCommand": "bash scripts/ensure-host-mounts.sh || true",
+"postStartCommand": "bash .devcontainer/post-start.sh",
 
 // gpu/devcontainer.json
 "initializeCommand": "bash scripts/ensure-host-mounts.sh || true; bash .devcontainer/../scripts/check-nvidia-symlinks.sh 2>/dev/null || true",
-"postStartCommand": "nvidia-smi > /dev/null 2>&1 && echo '[GPU] Access OK' || echo '[GPU] WARNING: GPU access lost.'"
+"postStartCommand": "bash .devcontainer/post-start.sh; nvidia-smi > /dev/null 2>&1 && echo '[GPU] Access OK' || echo '[GPU] WARNING: GPU access lost. Container restart required.' >&2"
 ```
 
 - **`ensure-host-mounts.sh`（CPU/GPU 共通）**: bind mount 対象（`~/.gitconfig` `~/.config/gh`）が
   ホストに無いと、Docker が**ディレクトリとして自動作成**してしまい、以後ホストの git が
   `fatal: ... is a directory` で動かなくなります。コンテナ作成前に正しい種別で用意します
+- **`post-start.sh` は CPU / GPU 共通**です。GPU 側は同じ `postStartCommand` に
+  GPU アクセス確認を**足している**だけで、置き換えてはいません
+  （置き換えると `claude()` ラッパーの注入が GPU 環境だけ失われます）
 - **GPU のみ**: コンテナ起動ごとに GPU アクセスを確認。ホストの再起動等で
   GPU アクセスが失われた場合に警告を表示します
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -159,13 +159,34 @@
 
 **何をしているか**: vscode ユーザーがパスワードなしで root 権限を取得できます。
 
+**前提**: コンテナの**既定ユーザーは非 root（`vscode`）**です。`.devcontainer/Dockerfile` の末尾で
+`USER vscode` に切り替えているため、`docker compose run` / `docker exec` を
+**引数なしで**叩いた場合も root にはなりません（#141）。
+
+**★ これは「root になれない」という意味ではありません。**
+`docker exec -u 0` / `docker run --user root` を指定すれば sudo 無しで root になれます。
+コンテナの USER 指定は**既定値**であって、境界ではありません。
+
 **リスク**:
-- コンテナ内で root として任意の操作が可能
+- コンテナ内で `sudo` により root として任意の操作が可能
+- `-u 0` を明示すれば sudo を経ずに root で起動できる（USER 指定では防げない）
 
 **緩和要因**:
 - DevContainer の標準的な設定
+- 既定では非 root で動作するため、**うっかり root で作業する**事故は減る
 - コンテナ外のホスト環境には影響しない（Docker-outside-of-Docker を除く）
 - 開発環境では一般的に許容される
+
+**`/workspace` の所有者について**: 非 root 化の狙いの一つは、bind mount した
+`/workspace`（ホストのリポジトリ）に root 所有ファイルを残さないことです。
+ただし上記のとおり `sudo` や `-u 0` を使えば root 所有ファイルは作れるため、
+**保証ではなく既定の改善**です。
+なお macOS の Docker Desktop は UID を写像するため、この差はホスト側から観測できません
+（root で作ったファイルもホストユーザー所有に見える）。**差が出るのは Linux ホストです。**
+
+**依存関係（変更時の注意）**: `docker-outside-of-docker` feature は、非 root ユーザーから
+Docker socket を使えるようにする権限調整に `sudo` を使います。
+`NOPASSWD` を外す場合は、この依存を先に解消してください。
 
 ## 総合評価
 


### PR DESCRIPTION
Closes #141

## 変更

1. **uv を `/usr/local/bin` へ**（`UV_INSTALL_DIR` ＋ `INSTALLER_NO_MODIFY_PATH=1`）。
   `ENV PATH="/root/.local/bin:${PATH}"` を削除。既定 PATH に含まれる場所に置くことで
   **PATH の書き換えそのものを不要にした**
2. **Dockerfile 末尾に `WORKDIR /workspace` ＋ `USER $USERNAME`**。ビルド段階は root のまま
3. **`ARG USER_UID` / `USER_GID` に既定値 1000**（レビューで見つかった退行の修正。下記）

## 実測

**CPU**: `devcontainer up` = `{"outcome":"success","remoteUser":"vscode"}`。
features 導入・`updateRemoteUserUID`・postCreate（sudo 6箇所）・postStart すべて完走。
起動後: `uid=1000(vscode)`, `pwd=/workspace`, `uv 0.12.1 (/usr/local/bin/uv)`, `docker 29.7.1`。

**GPU**: 33.3GB の amd64 イメージを取得しエミュレーションでビルド → EXIT 0。
`id -u`=1000/`vscode`、uv・claude・gh・sudo・`import torch` すべて動作。
**最大のリスクだった「NVIDIA entrypoint が root 前提か」は否定された。**

## レビューで見つかり修正した退行

`ARG USER_UID` に既定値が無く、build-arg 無しでビルドすると `getent group`（引数なし）が
exit 0 を返して **vscode が作られないままビルドが成功**していた。
変更前は `USER` 行が無く root で起動していたので無症状だったが、
`USER $USERNAME` を足したことで **`unable to find user vscode` で起動不能**になる。
対照実験込みで再現・修正を確認済み。

## PASS と書かなかった項目

**`/workspace` に root 所有ファイルが残らないこと（V17）は判定不能。**
対照実験の結果、**root で作ったファイルもホストからは同じ所有者に見える**
（macOS Docker Desktop の UID 写像）。この測定には検出力が無く、
**変更前でも「PASS」に見えた**はずのもの。判定できるのは Linux ホストだけ。

GPU 実機での起動も未検証。両方を **#142（`user-action`）** に切り出し、
親 #139 にも「成功条件5 は未充足」として記録した。

## 副産物: #64 の事実誤認を訂正

非 root ユーザーが **sudo 無しで `docker ps` を実行でき、`docker run -v /:/host` も通る**
ことを実測。`docker-outside-of-docker` feature が docker グループに入れるため。
「`docker.sock` はマウントしていない」という以前の記載は誤りで、[#64 に訂正済み](https://github.com/AtsushiHashimoto/research-project-template/issues/64#issuecomment-5160326518)。

## ドキュメント

`docs/security.md` の「root 権限は sudo を明示したときだけ得られます」は**誤り**
（`docker exec -u 0` で取れる）のため訂正。`USER` は既定値であって境界ではない。
`devcontainer-internals.md` / `claude-san.md` の既存の記述ずれも修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)