### PR TITLE
fix(worktree): data/shared リンクの相対パス・張り直し・到達性検証

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -193,9 +193,28 @@ else
     PATH_TYPE=$(grep '"path_type"' "$CONFIG_FILE" | cut -d'"' -f4 || echo "absolute")
 fi
 
-# Resolve relative path
+# The store is always addressed absolutely for the checks below; the *link target*
+# may be relative.  Overwriting SHARED_DATA_PATH with the absolute form is what
+# silently defeated path_type=relative: the config asked for a relative link and got
+# an absolute one, which breaks when the repository is mounted at another path.
+STORE_ABS="$MAIN_REPO/$SHARED_DATA_PATH"
+SHARED_DATA_PATH="$STORE_ABS"
+
+if [[ ! -d "$STORE_ABS" ]]; then
+    error "shared store does not exist: $STORE_ABS
+Run ./scripts/init-data.sh in the main repository first."
+fi
+
+# Link target: relative when the config asks for it.  Computed with realpath, never
+# hardcoded -- a wrong depth points the link at a directory that does not exist and
+# data silently stops reaching the store.
 if [[ "$PATH_TYPE" == "relative" ]]; then
-    SHARED_DATA_PATH="$MAIN_REPO/$SHARED_DATA_PATH"
+    if ! LINK_TARGET=$(realpath --relative-to="$(pwd -P)/data" "$STORE_ABS" 2>/dev/null); then
+        warn "cannot compute a relative path to $STORE_ABS; falling back to absolute"
+        LINK_TARGET="$STORE_ABS"
+    fi
+else
+    LINK_TARGET="$STORE_ABS"
 fi
 
 echo -e "${GREEN}$(msg config):${NC}"
@@ -203,7 +222,12 @@ cat "$CONFIG_FILE"
 echo ""
 
 # Check existing symlink
-if [[ -L "data/shared" ]]; then
+# A link that does not reach the store is broken, not a user choice: skip the prompt
+# and let the repair below replace it.  Asking (or bailing out non-interactively)
+# would leave the worktree writing into a directory that is not the shared store.
+if [[ -L "data/shared" ]] && [[ "$(readlink -f "data/shared" || true)" != "$(readlink -f "$STORE_ABS")" ]]; then
+    warn "data/shared does not reach the shared store; it will be recreated"
+elif [[ -L "data/shared" ]]; then
     warn "$(msg symlink_exists):"
     ls -la data/shared
     echo ""
@@ -341,11 +365,47 @@ if [ -e "data/shared" ] && [ ! -L "data/shared" ]; then
     info "$(msg dir_replaced)"
 fi
 
+# A symlink that does not reach the store (wrong depth, or dangling) is replaced.
+# A link holds no data of its own, so this is always safe -- and ln -sfn would keep
+# a dangling link pointing at nothing.
+if [[ -L "data/shared" ]]; then
+    _cur=$(readlink -f "data/shared" || true)
+    if [[ "$_cur" != "$(readlink -f "$STORE_ABS")" ]]; then
+        warn "data/shared points somewhere other than the shared store; recreating
+  points to -> ${_cur:-<dangling>}
+  expected  -> $STORE_ABS"
+        rm -f "data/shared"
+    fi
+fi
+
 # Create symlink
 info "$(msg creating_symlink)"
-ln -sfn "$SHARED_DATA_PATH" data/shared
+ln -sfn "$LINK_TARGET" data/shared
 
-success "$(msg created): data/shared -> $SHARED_DATA_PATH"
+success "$(msg created): data/shared -> $LINK_TARGET"
+
+# ------------------------------------------------------------ reachability check
+# "ln exited 0" is not evidence.  The bug this guards against shipped a link that
+# looked right in `ls` while resolving inside the worktree, and nothing noticed
+# until data written through it disappeared with the worktree.
+_verify=$(readlink -f "data/shared" || true)
+if [[ "$_verify" != "$(readlink -f "$STORE_ABS")" ]]; then
+    error "verification failed: data/shared does not reach the shared store.
+  resolves to -> ${_verify:-<unresolvable>}
+  expected    -> $STORE_ABS"
+fi
+
+_probe="data/shared/.write-probe.$$"
+if ! touch "$_probe" 2>/dev/null; then
+    error "verification failed: cannot write through data/shared -> $STORE_ABS"
+fi
+if [[ ! -e "$STORE_ABS/$(basename "$_probe")" ]]; then
+    rm -f "$_probe"
+    error "verification failed: a write through data/shared did not appear in the store."
+fi
+rm -f "$_probe"
+
+success "verified: data/shared -> $STORE_ABS (resolves and is writable)"
 echo ""
 
 echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/tests/test_setup_worktree_shared.sh
+++ b/tests/test_setup_worktree_shared.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/setup-worktree.sh -- data/shared linking (#194).
+#
+# The bug: data/shared/.gitkeep was tracked, so checkout always created data/shared as
+# a real directory, and `ln -sf` then put the link INSIDE it (data/shared/shared).
+# Data written to data/shared never reached the shared store and died with the worktree.
+#
+# Everything runs against a throwaway repository under $TMPDIR; the real store is
+# never touched.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SETUP="$REPO_ROOT/scripts/setup-worktree.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+bad()  { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+check(){ if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$3', got '$2')"; fi; }
+
+# ------------------------------------------------------------------ fixture
+# A miniature repo with a main checkout, a store, and one worktree.
+setup_fixture() {
+    FIX=$(mktemp -d)
+    export FIX
+    (
+        cd "$FIX" || exit 1
+        git init -q main
+        cd main || exit 1
+        git config user.email t@example.com
+        git config user.name t
+        mkdir -p .claude data/shared/datasets scripts
+        cat > .claude/worktree-config.json <<'JSON'
+{"version":"1.1","shared_data_path":"data/shared","path_type":"relative"}
+JSON
+        cp "$SETUP" scripts/setup-worktree.sh
+        chmod +x scripts/setup-worktree.sh
+        # data/shared is deliberately NOT tracked -- that is the fix under test.
+        printf 'data/shared\nworktrees/\n' > .gitignore
+        echo marker > data/shared/datasets/store-marker.txt
+        git add -A >/dev/null
+        git commit -qm init
+        git worktree add -q worktrees/wt -b wt >/dev/null 2>&1
+    )
+    WT="$FIX/main/worktrees/wt"
+    STORE="$FIX/main/data/shared"
+}
+teardown_fixture() { [[ -n "${FIX:-}" ]] && rm -rf "$FIX"; }
+
+run_setup() { (cd "$WT" && bash scripts/setup-worktree.sh >/dev/null 2>&1); }
+
+resolved() { readlink -f "$WT/data/shared" 2>/dev/null || echo ""; }
+store_intact() { [[ -f "$STORE/datasets/store-marker.txt" ]] && echo yes || echo no; }
+
+echo "=== setup-worktree.sh: data/shared linking (#194) ==="
+
+# T1: the reported symptom -- a real directory holding only .gitkeep must become a link
+setup_fixture
+mkdir -p "$WT/data/shared" && touch "$WT/data/shared/.gitkeep"
+run_setup
+check "T1 real dir with .gitkeep -> link to store" "$(resolved)" "$(readlink -f "$STORE")"
+check "T1 result is a symlink" "$([[ -L "$WT/data/shared" ]] && echo yes || echo no)" "yes"
+teardown_fixture
+
+# T2: the nested-link artefact left by the old script must be repaired
+setup_fixture
+mkdir -p "$WT/data/shared" && ln -s "$STORE" "$WT/data/shared/shared"
+run_setup
+check "T2 nested link repaired" "$(resolved)" "$(readlink -f "$STORE")"
+teardown_fixture
+
+# T3: idempotent -- running twice leaves a working link
+setup_fixture
+run_setup
+run_setup
+check "T3 idempotent" "$(resolved)" "$(readlink -f "$STORE")"
+teardown_fixture
+
+# T4: a link with the wrong depth (the ../../ mistake in D-07) is rebuilt, not kept
+setup_fixture
+rm -rf "$WT/data/shared"
+mkdir -p "$WT/data" && ln -s ../../data/shared "$WT/data/shared"   # dangling
+run_setup
+check "T4 wrong-depth link rebuilt" "$(resolved)" "$(readlink -f "$STORE")"
+teardown_fixture
+
+# T5: real data in data/shared must stop the script, not be deleted
+setup_fixture
+mkdir -p "$WT/data/shared" && echo precious > "$WT/data/shared/precious.csv"
+run_setup
+check "T5 refuses (non-zero exit)" "$?" "1"
+check "T5 data preserved" "$([[ -f "$WT/data/shared/precious.csv" ]] && echo yes || echo no)" "yes"
+teardown_fixture
+
+# T6: ★ data/ itself is a symlink, so data/shared IS the store.
+# -L is false and -d is true here; classifying on those would delete the store.
+setup_fixture
+rm -rf "$WT/data"
+ln -s ../../data "$WT/data"
+run_setup
+check "T6 store NOT deleted" "$(store_intact)" "yes"
+check "T6 still resolves to store" "$(resolved)" "$(readlink -f "$STORE")"
+teardown_fixture
+
+# T7: refuses to run in the main repository (data/shared is the store there)
+setup_fixture
+(cd "$FIX/main" && bash scripts/setup-worktree.sh >/dev/null 2>&1)
+check "T7 refuses in main (non-zero exit)" "$?" "1"
+check "T7 store untouched" "$(store_intact)" "yes"
+check "T7 no nested link in store" "$([[ -e "$STORE/shared" ]] && echo yes || echo no)" "no"
+teardown_fixture
+
+# T8: path_type=relative must produce a relative link that still resolves
+setup_fixture
+run_setup
+check "T8 link is relative" "$(readlink "$WT/data/shared")" "../../../data/shared"
+check "T8 relative link resolves to store" "$(resolved)" "$(readlink -f "$STORE")"
+teardown_fixture
+
+# T9: a broken link must fail loudly rather than report success
+setup_fixture
+rm -rf "$WT/data/shared" "$STORE"
+run_setup
+check "T9 missing store -> non-zero exit" "$?" "1"
+teardown_fixture
+
+echo ""
+echo "=== $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## 元 issue

- omron-sinicx/delta-clip-dev#194 `bug: /worktree-setup が data/shared をリンク化できず入れ子リンクを作る`
- 下流 PR: omron-sinicx/delta-clip-dev#203（マージ済み）

## 動機

下流で `/worktree-setup` を実行したところ、`data/shared` がリンク化されず
`data/shared/shared` という入れ子リンクができた。`data/shared` に書いたデータは
worktree 側のパーティションに落ち、共有されず worktree 削除で消える状態だった。

下流の根本原因は **`data/shared/.gitkeep` が追跡されていたこと**で、これは
**テンプレート側では既に修正済み**だった（`.gitignore` に理由まで書かれている）。
下流が取り残されていただけなので、`.gitignore` は本 PR に含めない。

**ただし `scripts/setup-worktree.sh` には未修正の穴が3つ残っている。**
下流で書いた回帰テストを**テンプレートの現行版にそのまま当てて測った**結果:

| | 結果 |
|---|---|
| テンプレート現行版 | **12 passed, 3 failed** |
| 本 PR 適用後 | **15 passed, 0 failed** |

実ディレクトリの扱い・ストア誤削除の防止・main での実行拒否は**既に効いていた**（T1/T2/T5/T6/T7 は PASS）。
本 PR はその上に残った3件だけを埋める。

## 汎用性の根拠

**3件とも下流のドメイン事情に依存しない、スクリプト自体の欠陥である。**

1. **`path_type=relative` が効かない** — `SHARED_DATA_PATH` を絶対形で上書きしているため、
   設定が相対を要求しても絶対パスのリンクが作られる。
   リポジトリを別の絶対パスにマウントする環境（devcontainer など）で壊れる。
   **設定項目が存在するのに機能していない**という、設定を読む全プロジェクト共通の不具合
2. **壊れたリンクが張り直されない** — 非対話実行では既存 symlink を見て `exit 0` するため、
   誤った深さ・ぶら下がりリンクがそのまま残る。CI や自動処理から呼ぶ全プロジェクトで起きる
3. **到達性の検証が無い** — `ln` は壊れた結果を作っても 0 を返す。
   「作成した」ことと「共有ストアに届いている」ことは別であり、
   後者を確かめないと**データが消えるまで誰も気付かない**（下流で実際にそうなった）

## 変更内容

### 1. `path_type: relative` を尊重する

```bash
STORE_ABS="$MAIN_REPO/$SHARED_DATA_PATH"   # 検査は常に絶対で行う
LINK_TARGET=$(realpath --relative-to="$(pwd -P)/data" "$STORE_ABS")
```

`realpath --relative-to` で計算し、深さをハードコードしない。
相対化できない場合は絶対パスにフォールバックして警告する。
**深さのハードコードは実際に事故を起こしている**（下流の記録: `../../data/shared` と書いて
`worktrees/data/shared` を指し、データが共有ストアに届かなかった）。

あわせて、共有ストアが存在しない場合は最初にエラーにする。

### 2. ストアに到達しない symlink を張り直す

リンクは中身を持たないので置き換えは常に安全。
早期の対話ブロックも、**リンクが壊れている場合は質問せず修復に回す**ようにした
（壊れているのはユーザーの選択ではないため）。

### 3. 作成後に到達性を検証する

```bash
readlink -f data/shared == readlink -f "$STORE_ABS"   # 解決先の一致
touch data/shared/.write-probe.$$                     # 実際に書けるか
[ -e "$STORE_ABS/.write-probe.$$" ]                   # ストア側に現れるか
```

失敗したら非ゼロ終了する。**「作れたつもり」を残さない。**

### 4. 回帰テスト（新規）

`tests/test_setup_worktree_shared.sh` — 使い捨てリポジトリで9シナリオを検証。実ストアには触れない。

| | シナリオ |
|---|---|
| T1 | 実ディレクトリ + `.gitkeep` → リンク化 |
| T2 | 入れ子リンクの修復 |
| T3 | 冪等性 |
| T4 | **誤った深さ / ぶら下がりリンクの張り直し** ← 本 PR |
| T5 | 実データがあれば停止し、消さない |
| T6 | `data/` 自体が symlink でストア本体のとき、ストアを削除しない |
| T7 | main での実行を拒否し、ストア内に入れ子を作らない |
| T8 | **`path_type=relative` で相対リンク** ← 本 PR |
| T9 | **ストア不在なら非ゼロ終了** ← 本 PR |

T5〜T7 は既存の振る舞いを**固定する**ためのもの（現行版でも PASS）。回帰で失われないようにする。

## 品質チェック

- ✅ 汚染チェック（`grep` で下流固有語を確認。該当なし）
- ✅ **テンプレート上で回帰テスト 15/15 PASS**
- ✅ `shellcheck -x` 警告なし（`scripts/setup-worktree.sh`、テストとも）
- ✅ `bash -n` 構文チェック
- ✅ `.claude/rules/template/` は変更していない

## 含めなかったもの

- **`.gitignore`** — テンプレート側で既に修正済み（下流が取り残されていただけ）
- 下流固有のドキュメント・判断記録

---
*This PR was created via `/template-contribute`.*
